### PR TITLE
Add backtrack fixed point enumeration algorithm

### DIFF
--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/lattice/BacktrackSearchEnumerator.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/lattice/BacktrackSearchEnumerator.java
@@ -48,7 +48,7 @@ import java.util.function.Supplier;
  * 
  * <pre>
  * function search(projection, nextdim, maxdim)
- *   if nextdim > maxdim then
+ *   if nextdim &gt; maxdim then
  *     if f(projection) == projection then
  *       output projection;
  *     end if
@@ -174,6 +174,10 @@ public class BacktrackSearchEnumerator {
    *                               function is decreasing) or minimal (if monotone
    *                               function is increasing) extensions of the
    *                               projection to full lattice elements.
+   * @param toFullSolution         function with arguments {@code (proj, projdim)}
+   *                               that produces a full lattice element from a
+   *                               projection representation (of full dimension
+   *                               count)
    * @param projector              function with arguments {@code (elem, projdim)}
    *                               that projects a full lattice element to
    *                               {@code projdim} dimensions.
@@ -190,8 +194,7 @@ public class BacktrackSearchEnumerator {
   public static <T, U> Iterable<T> enumerateLattice(Function<T, T> monotoneFunction, Supplier<U> initialProjection,
       int dimensions, ObjIntFunction<U, Iterable<U>> partialExtender,
       ObjIntFunction<U, Iterable<T>> maxExtensionEnumerator, ObjIntFunction<U, T> toFullSolution,
-      ObjIntFunction<T, U> projector, BiObjIntPredicate<U> projectionEqComparator,
-      ObjIntPredicate<U> skipProjection) {
+      ObjIntFunction<T, U> projector, BiObjIntPredicate<U> projectionEqComparator, ObjIntPredicate<U> skipProjection) {
     return () -> new Iterator<T>() {
 
       private T nextValue = null;
@@ -245,8 +248,7 @@ public class BacktrackSearchEnumerator {
           projectionPath.add(init);
           first = false;
         }
-        loop:
-        while (nextValue == null && !projectionPath.isEmpty()) {
+        loop: while (nextValue == null && !projectionPath.isEmpty()) {
           int nextDimension = projectionPath.size();
           int currentDimension = nextDimension - 1;
           if (currentDimension >= dimensions) {

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/lattice/BacktrackSearchEnumerator.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/lattice/BacktrackSearchEnumerator.java
@@ -1,0 +1,279 @@
+/*
+ * This file is part of netroles.
+ *
+ * netroles is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * netroles is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.ethz.sn.visone3.roles.lattice;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * This enumeration algorithm searches fixed points of a monotone function on a
+ * specific underlying lattice by exploiting that the elements of a lattice can
+ * be decomposed into several dimensions, so that projections of a lattice
+ * element to a given set of dimensions can be obtained as well as extensions of
+ * a given projection to more dimensions, or the set of extremal extensions of a
+ * projection to full lattice elements under the lattice ordering can be listed.
+ * 
+ * <p>
+ * This enumeration algorithm thus needs at least the following ingredients
+ * besides the monotone function f:
+ * <ul>
+ * <li>a way to decompose lattice elements into several dimensions, including an
+ * easy way to project to a lower number of dimensions,</li>
+ * <li>an iterable that produces all extensions of a projection by another
+ * dimension, as well as</li>
+ * <li>an iterable over all extremal extensions of a projection to full lattice
+ * elements under the lattice ordering.</li>
+ * </ul>
+ * 
+ * Fixed points are then essentially found using the following algorithm for
+ * monotone function f:
+ * 
+ * <pre>
+ * function search(projection, nextdim, maxdim)
+ *   if nextdim > maxdim then
+ *     if f(projection) == projection then
+ *       output projection;
+ *     end if
+ *   else
+ *     for all extensions e of projection by dimension nextdim do
+ *       if there is an extremal extension m of e to a full lattice element
+ *           such that e is a projection of f(m) then
+ *         search(e, nextdim + 1, maxdim);
+ *       end if
+ *     end for
+ *   end if
+ * end function
+ * 
+ * // initial call to start enumeration 
+ * search(0-dimension projection, 1, n)
+ * </pre>
+ * 
+ * Generally, the algorithm has to do little bookkeeping, and it performs well
+ * under two conditions:
+ * <ul>
+ * <li>if it is easy to generate another extension of a projection by a single
+ * dimension, and</li>
+ * <li>if there are only few extremal extensions of a projection to a full
+ * lattice element, and these are easy to generate.</li>
+ * </ul>
+ * 
+ * These conditions tend to be satisfied if the meet (if f is increasing
+ * monotone) or join (if f is decreasing monotone) act on the decomposition of
+ * lattice elements into dimensions essentially dimension-wise. For example,
+ * this is the case on the lattice of binary relations, where meet and join
+ * correspond to set intersection/union (if binary relations are modeled as sets
+ * of pairs) or component-wise minimum/maximum (if binary relations are
+ * represented as binary matrices).
+ */
+public class BacktrackSearchEnumerator {
+
+  private BacktrackSearchEnumerator() {
+
+  }
+
+  /**
+   * Represents a function that accepts an object and an integer and produces a
+   * result.
+   * 
+   * @param <T> the type of the first argument.
+   * @param <R> the type of the result.
+   */
+  @FunctionalInterface
+  public interface ObjIntFunction<T, R> {
+    /**
+     * Applies a function to the given arguments.
+     * 
+     * @param arg1 the first argument.
+     * @param arg2 the second argument.
+     * @return the result of the function.
+     */
+    public R apply(T arg1, int arg2);
+  }
+
+  /**
+   * Represents a predicate that accepts an object and an integer.
+   * 
+   * @param <T> the type of the first argument.
+   */
+  @FunctionalInterface
+  public interface ObjIntPredicate<T> {
+    /**
+     * Evaluates the predicate on the given arguments.
+     * 
+     * @param arg1 the first argument.
+     * @param arg2 the second argument.
+     * @return true if the arguments match the predicate, false otherwise.
+     */
+    public boolean test(T arg1, int arg2);
+  }
+
+  /**
+   * Represents a predicate that accepts two object arguments and an integer.
+   * 
+   * @param <T> the type of the first and second argument.
+   */
+  @FunctionalInterface
+  public interface BiObjIntPredicate<T> {
+    /**
+     * Evaluates the predicate on the given arguments.
+     * 
+     * @param arg1 the first argument.
+     * @param arg2 the second argument.
+     * @param arg3 the third argument.
+     * @return true if the arguments match the predicate, false otherwise.
+     */
+    public boolean test(T arg1, T arg2, int arg3);
+  }
+
+  /**
+   * Produces an iterable to enumerate the fixed point lattice of an increasing or
+   * decreasing monotone function.
+   * 
+   * <p>
+   * The iterator might interrupt its search for the next fixed point if the
+   * thread is interrupted. In this case, the iterator's {@code hasNext()} method
+   * returns false (and {@code next()} throws an exception if a prior call to
+   * {@code hasNext()} after the previous call do {@code next()} has not returned
+   * true). The thread's interrupted flag is not reset by the fixed point search
+   * algorithm. To recover, you may clear the thread's interrupted flag and call
+   * {@code hasNext()} again.
+   * 
+   * @param <T>                    the type of lattice elements.
+   * @param <U>                    the type of projections.
+   * @param monotoneFunction       increasing or decreasing monotone function that
+   *                               always produces a fixed point after a single
+   *                               invocation.
+   * @param initialProjection      the supplier of the initial projection to zero
+   *                               dimensions to start the search from.
+   * @param dimensions             number of dimensions lattice elements can be
+   *                               decomposed into.
+   * @param partialExtender        function with arguments {@code (proj, nextdim)}
+   *                               that produces all extensions of a projection by
+   *                               adding another dimension at index
+   *                               {@code nextdim}.
+   * @param maxExtensionEnumerator function with arguments {@code (proj, projdim)}
+   *                               that produces the maximal (if the monotone
+   *                               function is decreasing) or minimal (if monotone
+   *                               function is increasing) extensions of the
+   *                               projection to full lattice elements.
+   * @param projector              function with arguments {@code (elem, projdim)}
+   *                               that projects a full lattice element to
+   *                               {@code projdim} dimensions.
+   * @param projectionEqComparator predicate with arguments
+   *                               {@code (proj1, proj2, projdim)} that says
+   *                               whether the two projections with
+   *                               {@code projdim} dimensions are equal.
+   * @param skipProjection         predicate that says whether this projection and
+   *                               all its extensions should be skipped.
+   * @return an iterable that enumerates all fixed points of
+   *         {@code monotoneFunction} which are not skipped according to the
+   *         predicate.
+   */
+  public static <T, U> Iterable<T> enumerateLattice(Function<T, T> monotoneFunction, Supplier<U> initialProjection,
+      int dimensions, ObjIntFunction<U, Iterable<U>> partialExtender,
+      ObjIntFunction<U, Iterable<T>> maxExtensionEnumerator, ObjIntFunction<U, T> toFullSolution,
+      ObjIntFunction<T, U> projector, BiObjIntPredicate<U> projectionEqComparator,
+      ObjIntPredicate<U> skipProjection) {
+    return () -> new Iterator<T>() {
+
+      private T nextValue = null;
+      private boolean first = true;
+
+      private List<U> projectionPath = new ArrayList<>(dimensions + 1);
+      private List<Iterator<U>> partialExtensionsPath = new ArrayList<>(dimensions);
+
+      @Override
+      public boolean hasNext() {
+        if (nextValue == null) {
+          findNext();
+        }
+        return nextValue != null;
+      }
+
+      @Override
+      public T next() {
+        if (!hasNext()) {
+          throw new NoSuchElementException();
+        }
+        T result = nextValue;
+        nextValue = null;
+        return result;
+      }
+
+      private void handleLeaf(U leaf) {
+        T fullExtension = toFullSolution.apply(leaf, dimensions);
+        if (fullExtension.equals(monotoneFunction.apply(fullExtension))) {
+          nextValue = fullExtension;
+        }
+      }
+
+      private boolean hasProjectedFixedPoint(U projection, int numDimProjection) {
+        if (skipProjection != null && skipProjection.test(projection, numDimProjection)) {
+          return false;
+        }
+        for (T maxExtension : maxExtensionEnumerator.apply(projection, numDimProjection)) {
+          T fixedPoint = monotoneFunction.apply(maxExtension);
+          if (projectionEqComparator.test(projection, projector.apply(fixedPoint, numDimProjection),
+              numDimProjection)) {
+            return true;
+          }
+        }
+        return false;
+      }
+
+      private void findNext() {
+        if (first) {
+          U init = initialProjection.get();
+          projectionPath.add(init);
+          first = false;
+        }
+        loop:
+        while (nextValue == null && !projectionPath.isEmpty()) {
+          int nextDimension = projectionPath.size();
+          int currentDimension = nextDimension - 1;
+          if (currentDimension >= dimensions) {
+            handleLeaf(projectionPath.remove(currentDimension));
+          } else {
+            U projection = projectionPath.get(currentDimension);
+            if (partialExtensionsPath.size() <= currentDimension) {
+              partialExtensionsPath.add(partialExtender.apply(projection, currentDimension).iterator());
+            }
+            Iterator<U> partialExtensions = partialExtensionsPath.get(currentDimension);
+            while (partialExtensions.hasNext()) {
+              U partialExtension = partialExtensions.next();
+              if (hasProjectedFixedPoint(partialExtension, nextDimension)) {
+                projectionPath.add(partialExtension);
+                continue loop;
+              }
+              if (Thread.currentThread().isInterrupted()) {
+                return;
+              }
+            }
+            if (!partialExtensions.hasNext()) {
+              partialExtensionsPath.remove(currentDimension);
+              projectionPath.remove(currentDimension);
+            }
+          }
+        }
+      }
+    };
+  }
+}

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/lattice/CoverEnumerators.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/lattice/CoverEnumerators.java
@@ -28,7 +28,7 @@ import ch.ethz.sn.visone3.lang.PrimitiveCollections;
 import ch.ethz.sn.visone3.lang.PrimitiveList;
 import ch.ethz.sn.visone3.roles.blocks.Converters;
 import ch.ethz.sn.visone3.roles.blocks.RoleConverter;
-import ch.ethz.sn.visone3.roles.lattice.FixedPointEnumerator.CoverEnumerator;
+import ch.ethz.sn.visone3.roles.lattice.DepthFirstSearchEnumerator.CoverEnumerator;
 import ch.ethz.sn.visone3.roles.structures.BinaryRelation;
 import ch.ethz.sn.visone3.roles.structures.Ranking;
 import ch.ethz.sn.visone3.roles.structures.RelationBuilder;

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/lattice/DepthFirstSearchEnumerator.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/lattice/DepthFirstSearchEnumerator.java
@@ -67,7 +67,7 @@ import java.util.function.UnaryOperator;
  *   end for
  * end function
  * 
- * // start by calling: 
+ * // initial call to start enumeration
  * search(initial)
  * </pre>
  * 

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/lattice/DepthFirstSearchEnumerator.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/lattice/DepthFirstSearchEnumerator.java
@@ -28,8 +28,8 @@ import java.util.function.UnaryOperator;
 
 /**
  * This class implements an algorithm to search a lattice for fixed points of a
- * non-increasing or non-decreasing monotone function. By non-increasing, we
- * mean that {@code f(x) &lt;= x} for all x, and by non-decreasing, we man
+ * decreasing or increasing monotone function. By decreasing, we mean that
+ * {@code f(x) &lt;= x} for all x, and by increasing, we man
  * {@code f(x) &gt;= x} for all x.
  * 
  * <p>
@@ -40,14 +40,46 @@ import java.util.function.UnaryOperator;
  * point than brute force.
  * 
  * <p>
- * For a description of the algorithm, see
+ * The algorithm searches for fixed points by performing a depth-first search on
+ * the underlying lattice. It requires the following ingredients:
+ * <ul>
+ * <li>an increasing or decreasing monotone function which always outputs a
+ * fixed point after a single invocation,</li>
+ * <li>an initial lattice element to start the search from,</li>
+ * <li>an enumerator of lower covers (if the monotone function is decreasing) or
+ * upper covers (if increasing), as well as</li>
+ * <li>a predicate that says whether a lattice element is the descendant of a
+ * cover of another lattice element which has been enumerated before.
+ * </ul>
+ * 
+ * <p>
+ * Essentially, fixed points are then found by the following (recursive)
+ * algorithm for monotone function f (omitting all necessary bookkeeping):
+ * 
+ * <pre>
+ * function search(fixpoint)
+ *   output fixpoint;
+ *   for all covers c of fixpoint do
+ *     newfixpoint = f(c)
+ *     if newfixpoint has not been searched before then
+ *       search(newfixpoint);
+ *     end
+ *   end for
+ * end function
+ * 
+ * // start by calling: 
+ * search(initial)
+ * </pre>
+ * 
+ * <p>
+ * For a detailed description of the algorithm, see
  * 
  * <p>
  * Julian Müller (2023). Enumerating Tarski fixed points of binary relations.
  * arXiv:2308.07923.
  * 
  * <p>
- * This algorithm is an optimized and improved version of the algorithm
+ * This algorithm is an improved version of the breadth-first search algorithm
  * described in:
  * 
  * <p>
@@ -55,9 +87,9 @@ import java.util.function.UnaryOperator;
  * complements. Journal of Economic Theory 135(1):514-532.
  * doi:10.1016/j.jet.2006.06.001
  */
-public class FixedPointEnumerator {
+public class DepthFirstSearchEnumerator {
 
-  private FixedPointEnumerator() {
+  private DepthFirstSearchEnumerator() {
 
   }
 
@@ -89,6 +121,15 @@ public class FixedPointEnumerator {
   /**
    * Constructs an iterable to enumerate the fixed point lattice of a
    * non-increasing or non-decreasing monotone function.
+   * 
+   * <p>
+   * The iterator might interrupt its search for the next fixed point if the
+   * thread is interrupted. In this case, the iterator's {@code hasNext()} method
+   * returns false (and {@code next()} throws an exception if a prior call to
+   * {@code hasNext()} after the previous call do {@code next()} has not returned
+   * true). The thread's interrupted flag is not reset by the fixed point search
+   * algorithm. To recover, you may clear the thread's interrupted flag and call
+   * {@code hasNext()} again.
    * 
    * @param <T>               the type of lattice elements.
    * @param monotoneFunction  non-increasing or non-decreasing monotone function.

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/lattice/ProjectionEnumerators.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/lattice/ProjectionEnumerators.java
@@ -1,0 +1,339 @@
+/*
+ * This file is part of netroles.
+ *
+ * netroles is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * netroles is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.ethz.sn.visone3.roles.lattice;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import ch.ethz.sn.visone3.lang.ConstMapping;
+import ch.ethz.sn.visone3.lang.ConstMapping.OfInt;
+import ch.ethz.sn.visone3.lang.Mappings;
+import ch.ethz.sn.visone3.roles.structures.BinaryRelation;
+import ch.ethz.sn.visone3.roles.structures.BinaryRelations;
+
+/**
+ * Enumerators and other methods related to the projections of lattice elements
+ * used by the back-track search enumeration algorithm.
+ * 
+ * @see BacktrackSearchEnumerator
+ */
+public class ProjectionEnumerators {
+
+  private ProjectionEnumerators() {
+  }
+
+  /**
+   * Generates all extensions of a projection by a single dimension for binary
+   * relations.
+   * 
+   * @param projection    the projection.
+   * @param nextDimension the ordinal of the next dimension.
+   * @return an iterable over all projections when extending by another dimension.
+   */
+  public static Iterable<boolean[]> generateExtensionsBinaryRelations(boolean[] projection, int nextDimension) {
+    return () -> new Iterator<boolean[]>() {
+      private byte count = 0;
+
+      @Override
+      public boolean hasNext() {
+        return count < 2;
+      }
+
+      @Override
+      public boolean[] next() {
+        if (count >= 2) {
+          throw new NoSuchElementException();
+        }
+        projection[nextDimension] = count == 0;
+        ++count;
+        return projection;
+      }
+    };
+  }
+
+  /**
+   * Produces the extremal full binary relation extension of a projection
+   * according to the refinement ordering.
+   * 
+   * @param projection           the projection.
+   * @param numDimProjection     the number of dimensions in the projection.
+   * @param numDimBinaryRelation the number of dimensions of the binary relation
+   *                             (which is the domain size squared).
+   * @param maximal              true if the maximal extension is to be generated,
+   *                             else the minimal one is produced.
+   * @return an iterable producing the only maximal or minimal extension.
+   */
+  public static Iterable<BinaryRelation> extremalExtensionBinaryRelations(boolean[] projection, int numDimProjection,
+      int numDimBinaryRelation, boolean maximal) {
+    return () -> new Iterator<BinaryRelation>() {
+      private boolean notGenerated = true;
+
+      @Override
+      public boolean hasNext() {
+        return notGenerated;
+      }
+
+      @Override
+      public BinaryRelation next() {
+        if (!notGenerated) {
+          throw new NoSuchElementException();
+        }
+        notGenerated = false;
+        for (int i = numDimProjection; i < numDimBinaryRelation; ++i) {
+          projection[i] = maximal;
+        }
+        return projectionToBinaryRelation(projection, numDimBinaryRelation);
+      }
+    };
+  }
+
+  /**
+   * Returns true if the given binary relation is succeeded by some binary
+   * relation that has the given projection.
+   * 
+   * @param relation         the binary relation.
+   * @param projection       the projection.
+   * @param numDimProjection the number of dimensions of the projection.
+   * @return True if the binary relation is succeeded by some binary relation that
+   *         projects to the given projection, false otherwise.
+   */
+  public static boolean someExtensionSucceedsRelation(BinaryRelation relation, boolean[] projection,
+      int numDimProjection) {
+    int n = relation.domainSize();
+    int count = 0;
+    for (int i = 0; i < n && count < numDimProjection; ++i) {
+      for (int j = 0; j < n && count < numDimProjection; ++j) {
+        if (relation.contains(i, j) && !projection[count]) {
+          return false;
+        }
+        ++count;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Returns true if the given binary relation is preceded by some binary
+   * relations that has the given projection.
+   * 
+   * @param relation         the binary relation.
+   * @param projection       the projection.
+   * @param numDimProjection the number of dimensions of the projection.
+   * @return True if the binary relation is preceded by some binary relation that
+   *         projects to the given projection, false otherwise.
+   */
+  public static boolean someExtensionPrecedesRelation(BinaryRelation relation, boolean[] projection,
+      int numDimProjection) {
+    int n = relation.domainSize();
+    int count = 0;
+    for (int i = 0; i < n && count < numDimProjection; ++i) {
+      for (int j = 0; j < n && count < numDimProjection; ++j) {
+        if (!relation.contains(i, j) && projection[count]) {
+          return false;
+        }
+        ++count;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Converts a (full) projection representation to a binary relation.
+   * 
+   * @param projection    the projection.
+   * @param numDimensions the number of dimensions in the projection (which must
+   *                      equal the squared domain size).
+   * @return the conversion of the projection representation to a binary relation.
+   */
+  public static BinaryRelation projectionToBinaryRelation(boolean[] projection, int numDimensions) {
+    int domainSize = (int) Math.sqrt(numDimensions);
+    if (domainSize * domainSize != numDimensions) {
+      throw new IllegalArgumentException("numDimensions not square");
+    }
+    boolean[][] matrix = new boolean[domainSize][domainSize];
+    int count = 0;
+    for (int i = 0; i < domainSize; ++i) {
+      for (int j = 0; j < domainSize; ++j) {
+        matrix[i][j] = projection[count++];
+      }
+    }
+    return BinaryRelations.fromMatrix(matrix);
+  }
+
+  /**
+   * Projects a given binary relation the given number of dimensions.
+   * 
+   * @param relation      the binary relation.
+   * @param numDimensions the number of dimensions of the projection.
+   * @return the representation of the projection of the binary relation on the
+   *         given number of dimensions.
+   */
+  public static boolean[] projectRelation(BinaryRelation relation, int numDimensions) {
+    int domainSize = relation.domainSize();
+    boolean[] projection = new boolean[numDimensions];
+    int count = 0;
+    for (int i = 0; i < domainSize && count < numDimensions; ++i) {
+      for (int j = 0; j < domainSize && count < numDimensions; ++j) {
+        projection[count++] = relation.contains(i, j);
+      }
+    }
+    if (count < numDimensions) {
+      throw new IllegalArgumentException("numDimensions exceeds the squared domain size");
+    }
+    return projection;
+  }
+
+  /**
+   * Returns true if two projections of binary relations are equal.
+   * 
+   * @param proj1         the first projection.
+   * @param proj2         the second projection.
+   * @param numDimensions the number of dimensions of both projections.
+   * @return true if the projections are equal, false otherwise.
+   */
+  public static boolean projectionEquals(boolean[] proj1, boolean[] proj2, int numDimensions) {
+    return Arrays.equals(proj1, 0, numDimensions, proj2, 0, numDimensions);
+  }
+
+  /**
+   * Returns true if two projections of equivalences are equal.
+   * 
+   * @param proj1         the first projection.
+   * @param proj2         the second projection.
+   * @param numDimensions the number of dimensions of both projections.
+   * @return true if the projections are equal, false otherwise.
+   */
+  public static boolean projectionEquals(ConstMapping.OfInt proj1, ConstMapping.OfInt proj2, int numDimensions) {
+    for (int i = 0; i < numDimensions; ++i) {
+      if (proj1.getInt(i) != proj2.getInt(i)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Generates all extensions of a projection by a single dimension for
+   * equivalences.
+   * 
+   * @param projection    the projection.
+   * @param nextDimension the ordinal of the next dimension.
+   * @return an iterable over all projections when extending by another dimension.
+   */
+  public static Iterable<ConstMapping.OfInt> generateExtensionsEquivalences(ConstMapping.OfInt projection,
+      int nextDimension) {
+    int max = -1;
+    int[] value = projection.intStream().limit(nextDimension).toArray();
+    for (int val : value) {
+      max = Math.max(max, val);
+    }
+    int finalMax = max;
+    return () -> new Iterator<ConstMapping.OfInt>() {
+
+      int pos = -1;
+
+      @Override
+      public boolean hasNext() {
+        return pos <= finalMax;
+      }
+
+      @Override
+      public OfInt next() {
+        if (pos > finalMax) {
+          throw new NoSuchElementException();
+        }
+        ++pos;
+        int[] result = Arrays.copyOf(value, nextDimension + 1);
+        result[nextDimension] = pos;
+        return Mappings.wrapUnmodifiableInt(result);
+      }
+
+    };
+  }
+
+  /**
+   * Produces the minimal full equivalence extension of a projection according to
+   * the refinement ordering.
+   * 
+   * @param projection           the projection.
+   * @param numDimProjection     the number of dimensions in the projection.
+   * @param numDimBinaryRelation the number of dimensions of the equivalence
+   *                             (number of elements in the base set).
+   * @return an iterable producing the only minimal extension.
+   */
+  public static Iterable<ConstMapping.OfInt> minimalExtensionEquivalences(ConstMapping.OfInt projection,
+      int numPartialDimensions, int numActualDimensions) {
+    int max = 0;
+    int[] value = projection.intStream().limit(numPartialDimensions).toArray();
+    for (int val : value) {
+      max = Math.max(max, val);
+    }
+    value = Arrays.copyOf(value, numActualDimensions);
+    for (int i = numPartialDimensions; i < numActualDimensions; ++i) {
+      value[i] = ++max;
+    }
+    return Collections.singletonList(Mappings.wrapUnmodifiableInt(value));
+  }
+
+  /**
+   * Projects the equivalence to a lower number of dimensions.
+   * 
+   * <p>
+   * This particular implementation just returns the equivalence itself as a
+   * representation of its projection.
+   * 
+   * @param equivalence   the equivalence.
+   * @param numDimensions the number of dimensions to project to.
+   * @return the equivalence itself as a representation of its projection.
+   */
+  public static ConstMapping.OfInt projectEquivalence(ConstMapping.OfInt equivalence, int numDimensions) {
+    // projectionEquals() will deal with the fact that we are actually not
+    // projecting anything
+    return equivalence;
+  }
+
+  /**
+   * Returns true if the given equivalence is succeeded by one extension of the
+   * given projection.
+   * 
+   * @param equivalence      the given equivalence.
+   * @param projection       the projection.
+   * @param numDimProjection the number of dimensions of the projection.
+   * @return true if the equivalence is succeeded by one extension, false
+   *         otherwise.
+   */
+  public static boolean someExtensionSucceedsEquivalence(ConstMapping.OfInt equivalence, ConstMapping.OfInt projection,
+      int numDimProjection) {
+    int numDimEq = equivalence.size();
+    int[] equivalenceToProjectionClass = new int[numDimEq];
+
+    Arrays.fill(equivalenceToProjectionClass, -1);
+    for (int i = 0; i < numDimProjection; ++i) {
+      int eqClass = equivalence.getInt(i);
+      int projClass = projection.getInt(i);
+      int eqToProjClass = equivalenceToProjectionClass[eqClass];
+      if (eqToProjClass == -1) {
+        equivalenceToProjectionClass[eqClass] = projClass;
+      } else if (eqToProjClass != projClass) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/lattice/ProjectionEnumerators.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/lattice/ProjectionEnumerators.java
@@ -208,7 +208,12 @@ public class ProjectionEnumerators {
    * @return true if the projections are equal, false otherwise.
    */
   public static boolean projectionEquals(boolean[] proj1, boolean[] proj2, int numDimensions) {
-    return Arrays.equals(proj1, 0, numDimensions, proj2, 0, numDimensions);
+    for (int i = 0; i < numDimensions; ++i) {
+      if (proj1[i] != proj2[i]) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/lattice/ProjectionEnumerators.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/lattice/ProjectionEnumerators.java
@@ -276,21 +276,21 @@ public class ProjectionEnumerators {
    * Produces the minimal full equivalence extension of a projection according to
    * the refinement ordering.
    * 
-   * @param projection           the projection.
-   * @param numDimProjection     the number of dimensions in the projection.
-   * @param numDimBinaryRelation the number of dimensions of the equivalence
-   *                             (number of elements in the base set).
+   * @param projection        the projection.
+   * @param numDimProjection  the number of dimensions in the projection.
+   * @param numDimEquivalence the number of dimensions of the equivalence (number
+   *                          of elements in the base set).
    * @return an iterable producing the only minimal extension.
    */
   public static Iterable<ConstMapping.OfInt> minimalExtensionEquivalences(ConstMapping.OfInt projection,
-      int numPartialDimensions, int numActualDimensions) {
+      int numDimProjection, int numDimEquivalence) {
     int max = 0;
-    int[] value = projection.intStream().limit(numPartialDimensions).toArray();
+    int[] value = projection.intStream().limit(numDimProjection).toArray();
     for (int val : value) {
       max = Math.max(max, val);
     }
-    value = Arrays.copyOf(value, numActualDimensions);
-    for (int i = numPartialDimensions; i < numActualDimensions; ++i) {
+    value = Arrays.copyOf(value, numDimEquivalence);
+    for (int i = numDimProjection; i < numDimEquivalence; ++i) {
       value[i] = ++max;
     }
     return Collections.singletonList(Mappings.wrapUnmodifiableInt(value));

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/lattice/package-info.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/lattice/package-info.java
@@ -15,7 +15,48 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Algorithms for enumerating stable role structures and other fixed points on
- * finite lattices (especially of equivalences, rankings and binary relations).
+ * This package contains algorithms for enumerating stable role structures and
+ * other fixed points on finite lattices, including the necessary auxiliary
+ * methods to apply the algorithms on the lattices of equivalences, rankings and
+ * binary relations.
+ * 
+ * <p>
+ * The {@link ch.ethz.sn.visone3.roles.lattice.DepthFirstSearchEnumerator} and
+ * {@link ch.ethz.sn.visone3.roles.lattice.BacktrackSearchEnumerator} implement
+ * two algorithms to list fixed points of increasing or decreasing monotone
+ * functions. Both of them perform better than brute-force
+ * 
+ * <p>
+ * For role structures on equivalences, rankings and binary relations, you may
+ * use the {@link ch.ethz.sn.visone3.roles.lattice.StableRolesEnumeration}
+ * class, which applies the appropriate algorithm given the properties of the
+ * underlying lattice.
+ * 
+ * <p>
+ * If you want to choose the algorithm yourself or want to apply to different
+ * kinds of lattices, you should consider the following advantages and
+ * disadvantages:
+ * <ul>
+ * <li>The {@link ch.ethz.sn.visone3.roles.lattice.BacktrackSearchEnumerator}
+ * class has to do little bookkeeping. Moreover, it often works well when the
+ * lattice elements can be decomposed into several dimensions and the meet
+ * operation (if the monotone function is increasing) or the join operation (if
+ * decreasing) essentially acts component-wise in the dimensional decomposition.
+ * In this case, it also distributes evaluations of the monotone functions more
+ * equally between outputting fixed points.</li>
+ * <li>The {@link ch.ethz.sn.visone3.roles.lattice.DepthFirstSearchEnumerator}
+ * class performs more bookkeeping and does not distribute evaluations of
+ * monotone functions as equally, but it works better when the meet or join
+ * operation and the dimensional decomposition do not mesh as well. For example,
+ * this is the case for the join of equivalences, since the join of all
+ * equivalences having the same projection to some number of equivalences does
+ * not have the same projection; rather, there might be an exponential number of
+ * equivalences that are maximal among those having the same projection, and the
+ * algorithm in
+ * {@link ch.ethz.sn.visone3.roles.lattice.BacktrackSearchEnumerator} must test
+ * all of these to ascertain whether there is a fixed point with this projection
+ * or not.</li>
+ * </ul>
+ * 
  */
 package ch.ethz.sn.visone3.roles.lattice;

--- a/modules/roles-impl/src/test/java/ch/ethz/sn/visone3/roles/test/lattice/LatticeTest.java
+++ b/modules/roles-impl/src/test/java/ch/ethz/sn/visone3/roles/test/lattice/LatticeTest.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -51,7 +52,8 @@ import ch.ethz.sn.visone3.roles.blocks.RoleOperator;
 import ch.ethz.sn.visone3.roles.blocks.RoleOperators;
 import ch.ethz.sn.visone3.roles.impl.algorithms.Equivalences;
 import ch.ethz.sn.visone3.roles.lattice.CoverEnumerators;
-import ch.ethz.sn.visone3.roles.lattice.FixedPointEnumerator.CoverEnumerator;
+import ch.ethz.sn.visone3.roles.lattice.DepthFirstSearchEnumerator.CoverEnumerator;
+import ch.ethz.sn.visone3.roles.lattice.ProjectionEnumerators;
 import ch.ethz.sn.visone3.roles.lattice.StableRolesEnumeration;
 import ch.ethz.sn.visone3.roles.position.NetworkView;
 import ch.ethz.sn.visone3.roles.structures.BinaryRelation;
@@ -62,7 +64,8 @@ import ch.ethz.sn.visone3.roles.structures.RelationBuilders;
 
 public class LatticeTest {
 
-  // Political actors network from Doreian and Albert - Partitioning Political Actor Networks: Some
+  // Political actors network from Doreian and Albert - Partitioning Political
+  // Actor Networks: Some
   // Quantitative Tools for Analyzing Qualitative Networks
 
   private static final Integer z = null;
@@ -83,16 +86,23 @@ public class LatticeTest {
       { z, z, 1, z, z, 1, z, z, z, z, z, z, z, z }, //
   };
 
+  private static final Integer[][] cycleNetwork = { //
+      { z }, //
+      { 1, z }, //
+      { z, 1, z }, //
+      { z, z, 1, z }, //
+      { z, z, z, 1, z }, //
+      { z, z, z, z, 1, z }, //
+      { 1, z, z, z, z, 1, z }, //
+  };
+
   @Test
   public void testRegularEquivalencePoliticalActors() throws IOException {
     Network net = MatrixSource.fromAdjacency(politicalActorsNetwork, false).getNetwork();
 
-    Iterable<ConstMapping.OfInt> fixedPointsIterable = StableRolesEnumeration.EQUIVALENCE
-        .stableRolesUnderRestriction(
-            RoleOperators.EQUIVALENCE.regular()
-                .of(NetworkView.fromNetworkRelation(net, Direction.OUTGOING))
-                .make(),
-            Converters.singleClassEquivalence(net.countMonadicIndices()).apply(null));
+    Iterable<ConstMapping.OfInt> fixedPointsIterable = StableRolesEnumeration.EQUIVALENCE.stableRolesUnderRestriction(
+        RoleOperators.EQUIVALENCE.regular().of(NetworkView.fromNetworkRelation(net, Direction.OUTGOING)).make(),
+        Converters.singleClassEquivalence(net.countMonadicIndices()).apply(null));
 
     int count = 0;
     Iterator<ConstMapping.OfInt> iterator = fixedPointsIterable.iterator();
@@ -110,23 +120,15 @@ public class LatticeTest {
   public void testErrorTolerantExactEquivalencePoliticalActors() throws IOException {
     Network net = MatrixSource.fromAdjacency(politicalActorsNetwork, false).getNetwork();
 
-    RoleOperator<ConstMapping.OfInt> roleOp = Operators
-        .composeRoleOp(
-            Operators
-                .composeConv(
-                    Operators
-                        .composeConv(
-                            DistanceOperators.EQUIVALENCE.regular().equitable()
-                                .of(NetworkView.fromNetworkRelation(net,
-                                        Direction.OUTGOING))
-                                .make(),
-                            Converters.thresholdDistances((i, j) -> 1)),
-                    RoleOperators.BINARYRELATION.basic().symmetrize()),
-            Converters.weakComponentsAsEquivalence());
+    RoleOperator<ConstMapping.OfInt> roleOp = Operators.composeRoleOp(
+        Operators.composeConv(Operators.composeConv(
+            DistanceOperators.EQUIVALENCE.regular().equitable()
+                .of(NetworkView.fromNetworkRelation(net, Direction.OUTGOING)).make(),
+            Converters.thresholdDistances((i, j) -> 1)), RoleOperators.BINARYRELATION.basic().symmetrize()),
+        Converters.weakComponentsAsEquivalence());
 
     Iterable<ConstMapping.OfInt> fixedPointsIterable = StableRolesEnumeration.EQUIVALENCE
-        .stableRolesUnderRestriction(roleOp,
-            Converters.singleClassEquivalence(net.countMonadicIndices()).apply(null));
+        .stableRolesUnderRestriction(roleOp, Converters.singleClassEquivalence(net.countMonadicIndices()).apply(null));
 
     int count = 0;
     int countRealFixedPoints = 0;
@@ -151,12 +153,11 @@ public class LatticeTest {
     for (int i = 0; i < elemsPerClass; ++i) {
       stream = IntStream.concat(stream, IntStream.range(0, numClasses));
     }
-    ConstMapping.OfInt equivalence = Equivalences
-        .normalizePartition(Mappings.wrapUnmodifiableInt(stream.boxed()
-            .collect(Collectors.collectingAndThen(Collectors.toCollection(ArrayList::new), list -> {
-              Collections.shuffle(list);
-              return list.stream();
-            })).mapToInt(x -> x).toArray()));
+    ConstMapping.OfInt equivalence = Equivalences.normalizePartition(Mappings.wrapUnmodifiableInt(
+        stream.boxed().collect(Collectors.collectingAndThen(Collectors.toCollection(ArrayList::new), list -> {
+          Collections.shuffle(list);
+          return list.stream();
+        })).mapToInt(x -> x).toArray()));
     Random rand = new Random();
     int eqclazz1tosplit = 3 + rand.nextInt(numClasses - 4);
     int eqclazz2tosplittemp = 3 + rand.nextInt(numClasses - 5);
@@ -169,12 +170,9 @@ public class LatticeTest {
         refinedEq[i] = numClasses + 3 + rand.nextInt(3);
       }
     }
-    ConstMapping.OfInt refinedEquivalence = Equivalences
-        .normalizePartition(Mappings.wrapUnmodifiableInt(refinedEq));
-    ConstMapping.OfInt coarsenedEquivalence = Equivalences
-        .normalizePartition(Mappings.wrapUnmodifiableInt(equivalence.intStream()
-            .map(x -> x == eqclazz1tosplit || x == eqclazz2tosplit ? eqclazz1tosplit : x)
-            .toArray()));
+    ConstMapping.OfInt refinedEquivalence = Equivalences.normalizePartition(Mappings.wrapUnmodifiableInt(refinedEq));
+    ConstMapping.OfInt coarsenedEquivalence = Equivalences.normalizePartition(Mappings.wrapUnmodifiableInt(equivalence
+        .intStream().map(x -> x == eqclazz1tosplit || x == eqclazz2tosplit ? eqclazz1tosplit : x).toArray()));
 
     Set<ConstMapping.OfInt> foundPredecessors = new HashSet<>();
     CoverEnumerator<ConstMapping.OfInt, Mapping.OfInt> predEnumerator = CoverEnumerators
@@ -189,8 +187,7 @@ public class LatticeTest {
       assertTrue(foundPredecessors.add(predecessor));
       for (int i = 0; i < equivalence.size(); ++i) {
         for (int j = 0; j < equivalence.size(); ++j) {
-          assertTrue(predecessor.getInt(i) != predecessor.getInt(j)
-              || equivalence.getInt(i) == equivalence.getInt(j));
+          assertTrue(predecessor.getInt(i) != predecessor.getInt(j) || equivalence.getInt(i) == equivalence.getInt(j));
         }
       }
       ++count;
@@ -205,11 +202,10 @@ public class LatticeTest {
         }
       }
       previouslyIteratedAncestor |= isRefiningCurrentPredecessor;
-      boolean hasIteratedAncestor = predEnumerator
-          .isThereAncestorWhichIsCoverProducedBefore(refinedEquivalence, predecessor);
+      boolean hasIteratedAncestor = predEnumerator.isThereAncestorWhichIsCoverProducedBefore(refinedEquivalence,
+          predecessor);
       assertEquals(previouslyIteratedAncestor, hasIteratedAncestor);
-      assertFalse(predEnumerator
-          .isThereAncestorWhichIsCoverProducedBefore(coarsenedEquivalence, predecessor));
+      assertFalse(predEnumerator.isThereAncestorWhichIsCoverProducedBefore(coarsenedEquivalence, predecessor));
     }
     assertEquals(numClasses * ((1 << (elemsPerClass - 1)) - 1), count);
     assertThrows(NoSuchElementException.class, () -> predEnumerator.next());
@@ -226,8 +222,7 @@ public class LatticeTest {
       assertTrue(foundSuccessors.add(successor));
       for (int i = 0; i < equivalence.size(); ++i) {
         for (int j = 0; j < equivalence.size(); ++j) {
-          assertTrue(successor.getInt(i) == successor.getInt(j)
-              || equivalence.getInt(i) != equivalence.getInt(j));
+          assertTrue(successor.getInt(i) == successor.getInt(j) || equivalence.getInt(i) != equivalence.getInt(j));
         }
       }
       boolean isCoarseningCurrentSuccessor = true;
@@ -241,11 +236,10 @@ public class LatticeTest {
         }
       }
       previouslyIteratedAncestor |= isCoarseningCurrentSuccessor;
-      boolean hasIteratedAncestor = succEnumerator
-          .isThereAncestorWhichIsCoverProducedBefore(coarsenedEquivalence, successor);
+      boolean hasIteratedAncestor = succEnumerator.isThereAncestorWhichIsCoverProducedBefore(coarsenedEquivalence,
+          successor);
       assertEquals(previouslyIteratedAncestor, hasIteratedAncestor);
-      assertFalse(succEnumerator
-          .isThereAncestorWhichIsCoverProducedBefore(refinedEquivalence, successor));
+      assertFalse(succEnumerator.isThereAncestorWhichIsCoverProducedBefore(refinedEquivalence, successor));
       ++count;
     }
     assertEquals(numClasses * (numClasses - 1) / 2, count);
@@ -269,11 +263,9 @@ public class LatticeTest {
         }
       }
       binrel = BinaryRelations.fromMatrix(relArray);
-    } while (binrel.countRelationPairs() <= size * size / 5
-        && binrel.countRelationPairs() >= 4 * size * size / 5);
+    } while (binrel.countRelationPairs() <= size * size / 5 && binrel.countRelationPairs() >= 4 * size * size / 5);
 
-    boolean[][] coarsenedArray = Stream.of(relArray).map(x -> Arrays.copyOf(x, x.length))
-        .toArray(boolean[][]::new);
+    boolean[][] coarsenedArray = Stream.of(relArray).map(x -> Arrays.copyOf(x, x.length)).toArray(boolean[][]::new);
     int numAdditions = 0;
     do {
       int i = rand.nextInt(size);
@@ -285,8 +277,7 @@ public class LatticeTest {
     } while (numAdditions < 5);
     BinaryRelation coarsenedRelation = BinaryRelations.fromMatrix(coarsenedArray);
 
-    boolean[][] refinedArray = Stream.of(relArray).map(x -> Arrays.copyOf(x, x.length))
-        .toArray(boolean[][]::new);
+    boolean[][] refinedArray = Stream.of(relArray).map(x -> Arrays.copyOf(x, x.length)).toArray(boolean[][]::new);
     numAdditions = 0;
     do {
       int i = rand.nextInt(size);
@@ -325,11 +316,10 @@ public class LatticeTest {
         }
       }
       previouslyIteratedAncestor |= isRefiningCurrentPredecessor;
-      boolean hasIteratedAncestor = predEnumerator
-          .isThereAncestorWhichIsCoverProducedBefore(refinedRelation, predecessor);
+      boolean hasIteratedAncestor = predEnumerator.isThereAncestorWhichIsCoverProducedBefore(refinedRelation,
+          predecessor);
       assertEquals(previouslyIteratedAncestor, hasIteratedAncestor);
-      assertFalse(predEnumerator
-          .isThereAncestorWhichIsCoverProducedBefore(coarsenedRelation, predecessor));
+      assertFalse(predEnumerator.isThereAncestorWhichIsCoverProducedBefore(coarsenedRelation, predecessor));
     }
     assertEquals(binrel.countRelationPairs(), count);
     assertThrows(NoSuchElementException.class, () -> predEnumerator.next());
@@ -359,25 +349,21 @@ public class LatticeTest {
         }
       }
       previouslyIteratedAncestor |= isCoarseningCurrentSuccessor;
-      boolean hasIteratedAncestor = succEnumerator
-          .isThereAncestorWhichIsCoverProducedBefore(coarsenedRelation, successor);
+      boolean hasIteratedAncestor = succEnumerator.isThereAncestorWhichIsCoverProducedBefore(coarsenedRelation,
+          successor);
       assertEquals(previouslyIteratedAncestor, hasIteratedAncestor);
-      assertFalse(succEnumerator.isThereAncestorWhichIsCoverProducedBefore(refinedRelation,
-          successor));
+      assertFalse(succEnumerator.isThereAncestorWhichIsCoverProducedBefore(refinedRelation, successor));
       ++count;
     }
     assertEquals(size * size - binrel.countRelationPairs(), count);
     assertThrows(NoSuchElementException.class, () -> succEnumerator.next());
   }
 
-  private static Ranking rankingFromOrderedPartition(ConstMapping.OfInt partition,
-      boolean[][] ordering) {
-    RelationBuilder<? extends Ranking> builder = RelationBuilders
-        .denseSafeRankingBuilder(partition.size());
+  private static Ranking rankingFromOrderedPartition(ConstMapping.OfInt partition, boolean[][] ordering) {
+    RelationBuilder<? extends Ranking> builder = RelationBuilders.denseSafeRankingBuilder(partition.size());
     for (int i = 0; i < partition.size(); ++i) {
       for (int j = 0; j < partition.size(); ++j) {
-        if (partition.getInt(i) == partition.getInt(j)
-            || ordering[partition.getInt(i)][partition.getInt(j)]) {
+        if (partition.getInt(i) == partition.getInt(j) || ordering[partition.getInt(i)][partition.getInt(j)]) {
           builder.add(i, j);
         }
       }
@@ -394,12 +380,11 @@ public class LatticeTest {
     for (int i = 0; i < elemsPerClass; ++i) {
       stream = IntStream.concat(stream, IntStream.range(0, numClasses));
     }
-    ConstMapping.OfInt equivalence = Equivalences
-        .normalizePartition(Mappings.wrapUnmodifiableInt(stream.boxed()
-            .collect(Collectors.collectingAndThen(Collectors.toCollection(ArrayList::new), list -> {
-              Collections.shuffle(list);
-              return list.stream();
-            })).mapToInt(x -> x).toArray()));
+    ConstMapping.OfInt equivalence = Equivalences.normalizePartition(Mappings.wrapUnmodifiableInt(
+        stream.boxed().collect(Collectors.collectingAndThen(Collectors.toCollection(ArrayList::new), list -> {
+          Collections.shuffle(list);
+          return list.stream();
+        })).mapToInt(x -> x).toArray()));
 
     boolean[][] relArray = new boolean[numClasses][numClasses];
     Random rand = new Random();
@@ -443,8 +428,7 @@ public class LatticeTest {
 
           boolean transitivelyImplying = false;
           for (int k = 0; k < numClasses; ++k) {
-            if (i != k && j != k
-                && ((!relArray[i][k] && relArray[j][k]) || (!relArray[k][j] && relArray[k][i]))) {
+            if (i != k && j != k && ((!relArray[i][k] && relArray[j][k]) || (!relArray[k][j] && relArray[k][i]))) {
               transitivelyImplying = true;
               break;
             }
@@ -458,8 +442,7 @@ public class LatticeTest {
 
     Ranking ranking = rankingFromOrderedPartition(equivalence, relArray);
 
-    boolean[][] coarsenedArray = Stream.of(relArray).map(x -> Arrays.copyOf(x, x.length))
-        .toArray(boolean[][]::new);
+    boolean[][] coarsenedArray = Stream.of(relArray).map(x -> Arrays.copyOf(x, x.length)).toArray(boolean[][]::new);
 
     numAdditions = 0;
     do {
@@ -487,9 +470,8 @@ public class LatticeTest {
     int mergeClass1 = rand.nextInt(numClasses);
     int temp = rand.nextInt(numClasses - 1);
     int mergeClass2 = temp + (mergeClass1 <= temp ? 1 : 0);
-    ConstMapping.OfInt coarsenedEq = Equivalences
-        .normalizePartition(Mappings.wrapUnmodifiableInt(equivalence.intStream()
-            .map(x -> x == mergeClass1 || x == mergeClass2 ? mergeClass1 : x).toArray()));
+    ConstMapping.OfInt coarsenedEq = Equivalences.normalizePartition(Mappings.wrapUnmodifiableInt(
+        equivalence.intStream().map(x -> x == mergeClass1 || x == mergeClass2 ? mergeClass1 : x).toArray()));
     int largerMergedClass = Math.max(mergeClass1, mergeClass2);
     int smallerMergedClass = Math.min(mergeClass1, mergeClass2);
     boolean[][] coarsenedArray2 = new boolean[numClasses - 1][numClasses - 1];
@@ -502,8 +484,7 @@ public class LatticeTest {
     }
     Ranking coarsenedRanking2 = rankingFromOrderedPartition(coarsenedEq, coarsenedArray2);
 
-    boolean[][] refinedArray = Stream.of(relArray).map(x -> Arrays.copyOf(x, x.length))
-        .toArray(boolean[][]::new);
+    boolean[][] refinedArray = Stream.of(relArray).map(x -> Arrays.copyOf(x, x.length)).toArray(boolean[][]::new);
     numAdditions = 0;
     loop: do {
       int i = rand.nextInt(numClasses);
@@ -530,8 +511,7 @@ public class LatticeTest {
         refinedEq[i] = numClasses + rand.nextInt(3);
       }
     }
-    ConstMapping.OfInt refinedEquivalence = Equivalences
-        .normalizePartition(Mappings.wrapUnmodifiableInt(refinedEq));
+    ConstMapping.OfInt refinedEquivalence = Equivalences.normalizePartition(Mappings.wrapUnmodifiableInt(refinedEq));
     for (int i = 0; i < refinedEquivalence.size(); ++i) {
       int originalClassi = equivalence.getInt(i);
       int refinedClassi = refinedEquivalence.getInt(i);
@@ -547,8 +527,7 @@ public class LatticeTest {
     Ranking refinedRanking2 = rankingFromOrderedPartition(refinedEquivalence, refinedArray2);
 
     Set<Ranking> foundPredecessors = new HashSet<>();
-    CoverEnumerator<Ranking, Ranking> predEnumerator = CoverEnumerators
-        .lowerCoversRankings(ranking);
+    CoverEnumerator<Ranking, Ranking> predEnumerator = CoverEnumerators.lowerCoversRankings(ranking);
     int count = 0;
     boolean previouslyIteratedAncestor1 = false;
     boolean previouslyIteratedAncestor2 = false;
@@ -556,7 +535,8 @@ public class LatticeTest {
     while (predEnumerator.hasNext()) {
       Ranking predecessor = predEnumerator.next();
       assertEquals(ranking.domainSize(), predecessor.domainSize());
-      // assertEquals(ranking.countRelationPairs() - 1, predecessor.countRelationPairs());
+      // assertEquals(ranking.countRelationPairs() - 1,
+      // predecessor.countRelationPairs());
 
       assertTrue(foundPredecessors.add(predecessor));
       for (int i = 0; i < ranking.domainSize(); ++i) {
@@ -575,8 +555,8 @@ public class LatticeTest {
         }
       }
       previouslyIteratedAncestor1 |= isRefiningCurrentPredecessor;
-      boolean hasIteratedAncestor = predEnumerator
-          .isThereAncestorWhichIsCoverProducedBefore(refinedRanking1, predecessor);
+      boolean hasIteratedAncestor = predEnumerator.isThereAncestorWhichIsCoverProducedBefore(refinedRanking1,
+          predecessor);
       assertEquals(previouslyIteratedAncestor1, hasIteratedAncestor);
 
       isRefiningCurrentPredecessor = true;
@@ -589,27 +569,24 @@ public class LatticeTest {
         }
       }
       previouslyIteratedAncestor2 |= isRefiningCurrentPredecessor;
-      hasIteratedAncestor = predEnumerator
-          .isThereAncestorWhichIsCoverProducedBefore(refinedRanking2, predecessor);
+      hasIteratedAncestor = predEnumerator.isThereAncestorWhichIsCoverProducedBefore(refinedRanking2, predecessor);
       assertEquals(previouslyIteratedAncestor2, hasIteratedAncestor);
 
-      assertFalse(predEnumerator
-          .isThereAncestorWhichIsCoverProducedBefore(coarsenedRanking1, predecessor));
-      assertFalse(predEnumerator
-          .isThereAncestorWhichIsCoverProducedBefore(coarsenedRanking2, predecessor));
+      assertFalse(predEnumerator.isThereAncestorWhichIsCoverProducedBefore(coarsenedRanking1, predecessor));
+      assertFalse(predEnumerator.isThereAncestorWhichIsCoverProducedBefore(coarsenedRanking2, predecessor));
     }
     assertEquals(numClasses * ((1 << elemsPerClass) - 2) + nontransitivePairs, count);
     assertThrows(NoSuchElementException.class, () -> predEnumerator.next());
 
     Set<Ranking> foundSuccessors = new HashSet<>();
-    CoverEnumerator<Ranking, Ranking> succEnumerator = CoverEnumerators
-        .upperCoversRankings(ranking);
+    CoverEnumerator<Ranking, Ranking> succEnumerator = CoverEnumerators.upperCoversRankings(ranking);
     count = 0;
     previouslyIteratedAncestor1 = false;
     previouslyIteratedAncestor2 = false;
     while (succEnumerator.hasNext()) {
       Ranking successor = succEnumerator.next();
-      // assertEquals(binrel.countRelationPairs() + 1, successor.countRelationPairs());
+      // assertEquals(binrel.countRelationPairs() + 1,
+      // successor.countRelationPairs());
       assertEquals(ranking.domainSize(), successor.domainSize());
       assertTrue(foundSuccessors.add(successor));
       for (int i = 0; i < ranking.domainSize(); ++i) {
@@ -631,8 +608,8 @@ public class LatticeTest {
         val = val + 1;
       }
       previouslyIteratedAncestor1 |= isCoarseningCurrentSuccessor;
-      boolean hasIteratedAncestor = succEnumerator
-          .isThereAncestorWhichIsCoverProducedBefore(coarsenedRanking1, successor);
+      boolean hasIteratedAncestor = succEnumerator.isThereAncestorWhichIsCoverProducedBefore(coarsenedRanking1,
+          successor);
       assertEquals(previouslyIteratedAncestor1, hasIteratedAncestor);
 
       isCoarseningCurrentSuccessor = true;
@@ -645,16 +622,274 @@ public class LatticeTest {
         }
       }
       previouslyIteratedAncestor2 |= isCoarseningCurrentSuccessor;
-      hasIteratedAncestor = succEnumerator
-          .isThereAncestorWhichIsCoverProducedBefore(coarsenedRanking2, successor);
+      hasIteratedAncestor = succEnumerator.isThereAncestorWhichIsCoverProducedBefore(coarsenedRanking2, successor);
       assertEquals(previouslyIteratedAncestor2, hasIteratedAncestor);
-      assertFalse(succEnumerator.isThereAncestorWhichIsCoverProducedBefore(refinedRanking1,
-          successor));
-      assertFalse(succEnumerator.isThereAncestorWhichIsCoverProducedBefore(refinedRanking2,
-          successor));
+      assertFalse(succEnumerator.isThereAncestorWhichIsCoverProducedBefore(refinedRanking1, successor));
+      assertFalse(succEnumerator.isThereAncestorWhichIsCoverProducedBefore(refinedRanking2, successor));
       ++count;
     }
     assertEquals(nontransitivelyImplyingUnsetPairs, count);
     assertThrows(NoSuchElementException.class, () -> succEnumerator.next());
+  }
+
+  @Test
+  public void testBinaryRelationProjections() {
+    assertTrue(ProjectionEnumerators
+        .projectionEquals(ProjectionEnumerators.projectRelation(BinaryRelations.fromMatrix(new boolean[][] { //
+            { true, false, false, true }, //
+            { false, true, true, false }, //
+            { false, false, true, true }, //
+            { true, false, true, false } }), 5), new boolean[] { true, false, false, true, false }, 5));
+    assertFalse(ProjectionEnumerators
+        .projectionEquals(ProjectionEnumerators.projectRelation(BinaryRelations.fromMatrix(new boolean[][] { //
+            { true, false, false, true }, //
+            { false, true, true, false }, //
+            { false, false, true, true }, //
+            { true, false, true, false } }), 5), new boolean[] { true, false, true, true, false }, 5));
+    assertTrue(ProjectionEnumerators
+        .projectionEquals(ProjectionEnumerators.projectRelation(BinaryRelations.fromMatrix(new boolean[][] { //
+            { true, false, false, true }, //
+            { false, true, true, false }, //
+            { false, false, true, true }, //
+            { true, false, true, false } }), 6), new boolean[] { true, false, false, true, false, false }, 5));
+    assertTrue(ProjectionEnumerators
+        .projectionEquals(ProjectionEnumerators.projectRelation(BinaryRelations.fromMatrix(new boolean[][] { //
+            { true, false, false, true }, //
+            { false, true, true, false }, //
+            { false, false, true, true }, //
+            { true, false, true, false } }), 13), new boolean[] { true, false, false, true, false, false }, 5));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> ProjectionEnumerators.projectRelation(BinaryRelations.fromMatrix(new boolean[][] { //
+            { true, false, false, true }, //
+            { false, true, true, false }, //
+            { false, false, true, true }, //
+            { true, false, true, false } }), 17));
+
+    assertEquals(Collections.singletonList(BinaryRelations.fromMatrix(new boolean[][] { //
+        { true, false, false, true }, //
+        { true, false, false, false }, //
+        { false, false, false, false }, //
+        { false, false, false, false }, //
+    })), StreamSupport
+        .stream(ProjectionEnumerators.extremalExtensionBinaryRelations(new boolean[] { true, false, false, true, true,
+            true, true, false, true, false, true, true, true, false, false, false }, 5, 16, false).spliterator(), false)
+        .collect(Collectors.toList()));
+    assertEquals(Collections.singletonList(BinaryRelations.fromMatrix(new boolean[][] { //
+        { true, false, false, true }, //
+        { false, true, true, true }, //
+        { true, true, true, true }, //
+        { true, true, true, true }, //
+    })), StreamSupport
+        .stream(
+            ProjectionEnumerators.extremalExtensionBinaryRelations(new boolean[] { true, false, false, true, false,
+                true, true, false, true, false, true, true, true, false, false, false }, 5, 16, true).spliterator(),
+            false)
+        .collect(Collectors.toList()));
+    assertThrows(NoSuchElementException.class, () -> {
+      Iterator<BinaryRelation> it = ProjectionEnumerators.extremalExtensionBinaryRelations(new boolean[] { true, false,
+          false, true, true, true, true, false, true, false, true, true, true, false, false, false }, 5, 16, false)
+          .iterator();
+      it.next();
+      it.next();
+    });
+    assertThrows(IllegalArgumentException.class,
+        () -> ProjectionEnumerators.projectionToBinaryRelation(new boolean[16], 5));
+    assertThrows(IndexOutOfBoundsException.class,
+        () -> ProjectionEnumerators.projectionToBinaryRelation(new boolean[5], 16));
+
+    Set<ArrayList<Boolean>> result = new HashSet<>();
+    for (boolean[] extension : ProjectionEnumerators
+        .generateExtensionsBinaryRelations(new boolean[] { false, true, false, false, true, false, false }, 4)) {
+      ArrayList<Boolean> list = new ArrayList<>();
+      for (int i = 0; i < 5; ++i) {
+        list.add(extension[i]);
+      }
+      result.add(list);
+    }
+    assertEquals(
+        Stream.of(Arrays.asList(false, true, false, false, true), Arrays.asList(false, true, false, false, false))
+            .collect(Collectors.toSet()),
+        result);
+
+    assertThrows(NoSuchElementException.class, () -> {
+      Iterator<boolean[]> it = ProjectionEnumerators
+          .generateExtensionsBinaryRelations(new boolean[] { false, true, false, false, true, false, false }, 4)
+          .iterator();
+      it.next();
+      it.next();
+      it.next();
+    });
+
+    assertTrue(ProjectionEnumerators.someExtensionPrecedesRelation(BinaryRelations.fromMatrix(new boolean[][] { //
+        { true, false, true, false }, //
+        { true, true, true, true }, //
+        { true, true, true, true }, //
+        { true, true, true, true }, //
+    }), new boolean[] { true, false, true, false, true }, 5));
+    assertTrue(ProjectionEnumerators.someExtensionPrecedesRelation(BinaryRelations.fromMatrix(new boolean[][] { //
+        { true, false, true, false }, //
+        { true, true, true, true }, //
+        { true, true, true, true }, //
+        { true, true, true, true }, //
+    }), new boolean[] { true, false, true, false, false }, 5));
+    assertFalse(ProjectionEnumerators.someExtensionPrecedesRelation(BinaryRelations.fromMatrix(new boolean[][] { //
+        { true, false, true, false }, //
+        { true, true, true, true }, //
+        { true, true, true, true }, //
+        { true, true, true, true }, //
+    }), new boolean[] { true, true, true, false, true }, 5));
+    assertTrue(ProjectionEnumerators.someExtensionPrecedesRelation(BinaryRelations.fromMatrix(new boolean[][] { //
+        { true, false, true, false }, //
+        { false, true, true, true }, //
+        { true, true, true, true }, //
+        { true, true, true, true }, //
+    }), new boolean[] { true, false, true, false, false }, 5));
+    assertTrue(ProjectionEnumerators.someExtensionPrecedesRelation(BinaryRelations.fromMatrix(new boolean[][] { //
+        { true, false, true, false }, //
+        { false, true, true, true }, //
+        { true, true, false, true }, //
+        { true, true, true, true }, //
+    }), new boolean[] { true, false, true, false, false }, 5));
+    assertTrue(ProjectionEnumerators.someExtensionPrecedesRelation(BinaryRelations.fromMatrix(new boolean[][] { //
+        { true, false, true, false }, //
+        { false, false, false, false }, //
+        { false, false, false, false }, //
+        { false, false, false, false }, //
+    }), new boolean[] { true, false, true, false, false }, 5));
+
+    assertTrue(ProjectionEnumerators.someExtensionSucceedsRelation(BinaryRelations.fromMatrix(new boolean[][] { //
+        { true, false, true, false }, //
+        { true, false, false, false }, //
+        { false, false, false, false }, //
+        { false, false, false, false }, //
+    }), new boolean[] { true, false, true, false, true }, 5));
+    assertTrue(ProjectionEnumerators.someExtensionSucceedsRelation(BinaryRelations.fromMatrix(new boolean[][] { //
+        { true, false, true, false }, //
+        { true, false, false, false }, //
+        { false, false, false, false }, //
+        { false, false, false, false }, //
+    }), new boolean[] { true, true, true, false, true }, 5));
+    assertFalse(ProjectionEnumerators.someExtensionSucceedsRelation(BinaryRelations.fromMatrix(new boolean[][] { //
+        { true, false, true, false }, //
+        { true, false, false, false }, //
+        { false, false, false, false }, //
+        { false, false, false, false }, //
+    }), new boolean[] { true, false, true, false, false }, 5));
+    assertTrue(ProjectionEnumerators.someExtensionSucceedsRelation(BinaryRelations.fromMatrix(new boolean[][] { //
+        { true, false, true, false }, //
+        { false, false, false, false }, //
+        { false, false, false, false }, //
+        { false, false, false, false }, //
+    }), new boolean[] { true, false, true, false, true }, 5));
+    assertTrue(ProjectionEnumerators.someExtensionSucceedsRelation(BinaryRelations.fromMatrix(new boolean[][] { //
+        { true, false, true, false }, //
+        { false, true, true, true }, //
+        { true, true, false, true }, //
+        { true, true, true, true }, //
+    }), new boolean[] { true, false, true, false, true }, 5));
+    assertTrue(ProjectionEnumerators.someExtensionSucceedsRelation(BinaryRelations.fromMatrix(new boolean[][] { //
+        { true, false, true, false }, //
+        { false, true, true, true }, //
+        { true, true, true, true }, //
+        { true, true, true, true }, //
+    }), new boolean[] { true, false, true, false, true }, 5));
+  }
+
+  @Test
+  public void testEquivalenceProjections() {
+    assertTrue(ProjectionEnumerators.projectionEquals(Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 2),
+        ProjectionEnumerators.projectEquivalence(Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 1, 3, 2, 3, 4), 7),
+        7));
+    assertTrue(ProjectionEnumerators.projectionEquals(Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 2),
+        ProjectionEnumerators.projectEquivalence(Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 2, 3, 2, 3, 4), 7),
+        7));
+    assertFalse(ProjectionEnumerators.projectionEquals(Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 1, 2),
+        ProjectionEnumerators.projectEquivalence(Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 1, 3, 2, 3, 4), 7),
+        7));
+
+    assertEquals(Collections.singleton(Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 3, 4, 5, 6, 7, 8)),
+        StreamSupport.stream(ProjectionEnumerators
+            .minimalExtensionEquivalences(Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 1, 3, 2, 3, 4), 7, 13)
+            .spliterator(), false).collect(Collectors.toSet()));
+
+    assertEquals(Stream
+        .of(Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 0), Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 1),
+            Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 2), Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 3))
+        .collect(Collectors.toSet()),
+        StreamSupport.stream(ProjectionEnumerators
+            .generateExtensionsEquivalences(Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 1, 3, 2, 3, 4), 7)
+            .spliterator(), false).collect(Collectors.toSet()));
+
+    assertThrows(NoSuchElementException.class, () -> {
+      Iterator<ConstMapping.OfInt> it = ProjectionEnumerators
+          .generateExtensionsEquivalences(Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 1, 3, 2, 3, 4), 7)
+          .iterator();
+      for (int i = 0; i < 5; ++i) {
+        it.next();
+      }
+    });
+
+    assertTrue(ProjectionEnumerators.someExtensionSucceedsEquivalence(
+        Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 3, 4, 5, 6, 7, 8),
+        Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 2, 1, 0, 2, 3, 2), 7));
+    assertTrue(ProjectionEnumerators.someExtensionSucceedsEquivalence(
+        Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 3, 4, 5, 6, 7, 8),
+        Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 2), 7));
+    assertTrue(ProjectionEnumerators.someExtensionSucceedsEquivalence(
+        Mappings.wrapUnmodifiableInt(0, 1, 2, 0, 1, 3, 3, 4, 5, 6, 7, 8, 9),
+        Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 2, 1, 0, 2, 3, 2), 7));
+    assertFalse(ProjectionEnumerators.someExtensionSucceedsEquivalence(
+        Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 0, 2, 3, 4, 5, 6, 7, 8),
+        Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 2, 1, 0, 2, 3, 2), 7));
+    assertFalse(ProjectionEnumerators.someExtensionSucceedsEquivalence(
+        Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 1, 1, 2, 3, 4, 5, 6, 7),
+        Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 2, 1, 0, 2, 3, 2), 7));
+    assertTrue(ProjectionEnumerators.someExtensionSucceedsEquivalence(
+        Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 3, 4, 5, 6, 5, 7),
+        Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 2), 7));
+    assertTrue(ProjectionEnumerators.someExtensionSucceedsEquivalence(
+        Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2, 3, 4, 5, 1, 6, 7),
+        Mappings.wrapUnmodifiableInt(0, 1, 0, 0, 1, 2, 2), 7));
+  }
+
+  @Test
+  public void testEconomicalEquivalencePoliticalActors() throws IOException {
+    Network net = MatrixSource.fromAdjacency(politicalActorsNetwork, false).getNetwork();
+
+    Iterable<ConstMapping.OfInt> fixedPointsIterable = StableRolesEnumeration.EQUIVALENCE.stableRolesUnderExtension(
+        RoleOperators.EQUIVALENCE.regular().of(NetworkView.fromNetworkRelation(net, Direction.OUTGOING)).make(),
+        Converters.singleClassEquivalence(net.countMonadicIndices()).apply(null));
+
+    int count = 0;
+    Iterator<ConstMapping.OfInt> iterator = fixedPointsIterable.iterator();
+    while (iterator.hasNext()) {
+      ConstMapping.OfInt fixedPoint = iterator.next();
+      assertNotNull(fixedPoint);
+      ++count;
+    }
+    assertEquals(1, count);
+    assertThrows(NoSuchElementException.class, () -> iterator.next());
+  }
+
+  @Test
+  public void testEconomicalEquivalenceCycleNetwork() throws IOException {
+    Network net = MatrixSource.fromAdjacency(cycleNetwork, false).getNetwork();
+
+    RoleOperator<ConstMapping.OfInt> roleOp = RoleOperators.EQUIVALENCE.regular()
+        .of(NetworkView.fromNetworkRelation(net, Direction.OUTGOING)).make();
+    Iterable<ConstMapping.OfInt> fixedPointsIterable = StableRolesEnumeration.EQUIVALENCE
+        .stableRolesUnderExtension(roleOp, Mappings.intRange(0, net.countMonadicIndices()));
+
+    int count = 0;
+    Iterator<ConstMapping.OfInt> iterator = fixedPointsIterable.iterator();
+    while (iterator.hasNext()) {
+      ConstMapping.OfInt fixedPoint = iterator.next();
+      assertNotNull(fixedPoint);
+      assertEquals(fixedPoint, roleOp.extend(fixedPoint));
+      ++count;
+    }
+    assertEquals(142, count);
+    assertThrows(NoSuchElementException.class, () -> iterator.next());
   }
 }


### PR DESCRIPTION
Adds an alternative enumeration algorithm. This one tends to be faster (due to less bookkeeping overhead) when the lattice elements naturally decompose into several dimensions and this decomposition is consistent with the corresponding join and meet operations (e.g., because the join or meet operation essentially acts on each dimension independently). Specifically, the meet operation should have this structure if the fixed points of an increasing monotone function are sought, and the join operation should be like that for fixed points of a decreasing monotone function.

This is now the standard enumeration algorithm for enumerating stable role equivalences w.r.t. role extensions on the lattice of equivalences and for stable role structures on the lattice of binary relations, as these are cases where this algorithm reveals its strengths. 