### PR TITLE
extend Javadoc package and class descriptions

### DIFF
--- a/modules/core-api/src/main/java/ch/ethz/sn/visone3/algorithms/package-info.java
+++ b/modules/core-api/src/main/java/ch/ethz/sn/visone3/algorithms/package-info.java
@@ -15,6 +15,10 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Basic algorithms for networks.
+ * Provides basic algorithms for networks, such as methods for network traversal
+ * or connectedness.
+ * 
+ * <p>
+ * Users can access the algorithms using the {@link AlgoProvider} class.
  */
 package ch.ethz.sn.visone3.algorithms;

--- a/modules/core-api/src/main/java/ch/ethz/sn/visone3/networks/package-info.java
+++ b/modules/core-api/src/main/java/ch/ethz/sn/visone3/networks/package-info.java
@@ -15,6 +15,39 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Network representations.
+ * This package provides network representations.
+ * 
+ * <p>
+ * Network representations of a specific type can be created by obtaining a
+ * corresponding builder from
+ * {@link ch.ethz.sn.visone3.networks.NetworkProvider} and using it to specify
+ * the network structure. This results in the following typical invocation
+ * sequence:
+ * 
+ * <pre>
+ * // get builder
+ * NetworkBuilder builder = NetworkProvider.builder(dyadType);
+ * // add nodes and edges
+ * builder.ensureNode(node);
+ * builder.addEdge(source, target);
+ * // obtain network
+ * Network network = builder.build();
+ * </pre>
+ * 
+ * <p>
+ * Network representations can support four different kinds of perspectives on
+ * networks:
+ * <ul>
+ * <li>undirected graph perspective specified by
+ * {@link ch.ethz.sn.visone3.networks.UndirectedGraph},</li>
+ * <li>directed graph perspective specified by
+ * {@link ch.ethz.sn.visone3.networks.DirectedGraph},</li>
+ * <li>relational perspective specified by
+ * {@link ch.ethz.sn.visone3.networks.Relation}, and</li>
+ * <li>matrix perspective supported by method
+ * {@link ch.ethz.sn.visone3.networks.Network#asMatrix(Object, Object, ch.ethz.sn.visone3.lang.ConstMapping)}.</li>
+ * </ul>
+ * However, network representations are not required to support all of these
+ * perspectives.
  */
 package ch.ethz.sn.visone3.networks;

--- a/modules/core-api/src/main/java/ch/ethz/sn/visone3/progress/package-info.java
+++ b/modules/core-api/src/main/java/ch/ethz/sn/visone3/progress/package-info.java
@@ -28,6 +28,18 @@
  * 
  * <p>
  * If no listener has been registered before the first operation reporting
- * progress, a default listener printing to standard output might be installed.
+ * progress, a default listener printing to the standard logger might be
+ * installed.
+ * 
+ * <p>
+ * Operations reporting their own progress typically perform the following
+ * sequence of operations:
+ * 
+ * <pre>
+ * try (ProgressSource progressSource = ProgressProvider.getMonitor().newSource()) {
+ *   // repeatedly update progress by calling
+ *   progressSource.updateProgress(currentprogress, totalprogress, message);
+ * }
+ * </pre>
  */
 package ch.ethz.sn.visone3.progress;

--- a/modules/core-impl/src/main/java/ch/ethz/sn/visone3/algorithms/impl/package-info.java
+++ b/modules/core-impl/src/main/java/ch/ethz/sn/visone3/algorithms/impl/package-info.java
@@ -15,6 +15,9 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Implements basic algorithms for networks.
+ * Implements basic algorithms for networks. The algorithms are made available
+ * in the API using the {@link ch.ethz.sn.visone3.algorithms.AlgoProvider} class
+ * by registering a corresponding
+ * {@linkplain ch.ethz.sn.visone3.algorithms.AlgoService}.
  */
 package ch.ethz.sn.visone3.algorithms.impl;

--- a/modules/core-impl/src/main/java/ch/ethz/sn/visone3/networks/impl/package-info.java
+++ b/modules/core-impl/src/main/java/ch/ethz/sn/visone3/networks/impl/package-info.java
@@ -15,6 +15,9 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Default implementation of progress reporting feature.
+ * Network implementations. The implementations are made available in the API
+ * using the {@link ch.ethz.sn.visone3.networks.NetworkProvider} class by
+ * registering a corresponding
+ * {@linkplain ch.ethz.sn.visone3.networks.NetworkService}.
  */
 package ch.ethz.sn.visone3.networks.impl;

--- a/modules/io-api/src/main/java/ch/ethz/sn/visone3/io/Source.java
+++ b/modules/io-api/src/main/java/ch/ethz/sn/visone3/io/Source.java
@@ -25,16 +25,30 @@ import java.util.function.Function;
 
 /**
  * Specifies which and how parts of a data container are read.
+ * 
+ * <p>
+ * Depending on the underlying data format, the reading operation requires and
+ * supports more or less kinds of configuration. Using this interface, the
+ * following details can be specified:
+ * <ul>
+ * <li>the kind of network, as well as the variables defining the start and end
+ * points of dyads, using {@link #dyad(DyadType, String, String, Range)},</li>
+ * <li>the variable defining the nodes using {@link #monad(String, Range)},</li>
+ * <li>a pre-defined assignment of nodes and affiliations to ids using
+ * {@link #mergeNodes(ConstMapping)} and
+ * {@link #mergeAffiliations(ConstMapping)},</li>
+ * <li>the type and value range of node and link attributes using
+ * {@link #noderange(String, Range)} and {@link #linkrange(String, Range)},  as well as</li>
+ * <li>additional details supported by the data format by calling {@link #hint(Object, Object)}.</li>
+ * </ul>
  *
- * @param <H>
- *          Hint type.
+ * @param <H> Hint type.
  */
 public interface Source<H> extends AutoCloseable {
   /**
    * Typed conversion function.
    *
-   * @param <T>
-   *          data type.
+   * @param <T> data type.
    */
   interface Range<T> extends Function<String, T> {
 
@@ -68,14 +82,10 @@ public interface Source<H> extends AutoCloseable {
     /**
      * Constructs a new typed converter from string to the specified value type.
      * 
-     * @param <T>
-     *          the type of the produced value.
-     * @param clazz
-     *          the class object for the value type.
-     * @param defaultValue
-     *          the default value of the value type.
-     * @param conv
-     *          the actual conversion function.
+     * @param <T>          the type of the produced value.
+     * @param clazz        the class object for the value type.
+     * @param defaultValue the default value of the value type.
+     * @param conv         the actual conversion function.
      * @return the typed converter.
      */
     static <T> Range<T> of(final Class<T> clazz, T defaultValue, final Function<String, T> conv) {
@@ -107,33 +117,31 @@ public interface Source<H> extends AutoCloseable {
   boolean isAutoconfig();
 
   /**
-   * Sets the mapping from node indices to node ids that is used when reading from the source.
+   * Sets the mapping from node indices to node ids that is used when reading from
+   * the source.
    * 
-   * @param ids
-   *          mapping from node indices to node ids
+   * @param ids mapping from node indices to node ids
    */
   default void mergeNodes(final ConstMapping<String> ids) {
     throw new UnsupportedOperationException("merging nodes not supported");
   }
 
   /**
-   * Sets the mapping from affiliation indices to affiliation ids that is used when reading from the
-   * source.
+   * Sets the mapping from affiliation indices to affiliation ids that is used
+   * when reading from the source.
    * 
-   * @param ids
-   *          mapping from affiliation indices to affiliation ids
+   * @param ids mapping from affiliation indices to affiliation ids
    */
   default void mergeAffiliations(final ConstMapping<String> ids) {
     throw new UnsupportedOperationException("merging affiliations not supported");
   }
 
   /**
-   * Sets the node id attribute and the associated typed converter for monadic sources.
+   * Sets the node id attribute and the associated typed converter for monadic
+   * sources.
    * 
-   * @param varName
-   *          the variable name.
-   * @param range
-   *          the typed converter.
+   * @param varName the variable name.
+   * @param range   the typed converter.
    */
   default void monad(final String varName, final Range<?> range) {
     throw new UnsupportedOperationException("reading monadic variables not supported");
@@ -142,27 +150,20 @@ public interface Source<H> extends AutoCloseable {
   /**
    * Specifies the two incidence keys for dyadic sources.
    *
-   * @param type
-   *          Type of dyads.
-   * @param sourceVarName
-   *          source key.
-   * @param targetVarName
-   *          target key.
-   * @param range
-   *          Type of node id.
+   * @param type          Type of dyads.
+   * @param sourceVarName source key.
+   * @param targetVarName target key.
+   * @param range         Type of node id.
    */
-  default void dyad(final DyadType type, final String sourceVarName, final String targetVarName,
-      final Range<?> range) {
+  default void dyad(final DyadType type, final String sourceVarName, final String targetVarName, final Range<?> range) {
     throw new UnsupportedOperationException("reading networks not supported");
   }
 
   /**
    * Sets the typed converter to use for reading a dyadic variable.
    * 
-   * @param varName
-   *          the variable name
-   * @param range
-   *          the typed converter
+   * @param varName the variable name
+   * @param range   the typed converter
    */
   default void linkrange(final String varName, final Range<?> range) {
     throw new UnsupportedOperationException("reading link weights not supported");
@@ -171,10 +172,8 @@ public interface Source<H> extends AutoCloseable {
   /**
    * Sets the typed converter to use for reading a monadic variable.
    * 
-   * @param varName
-   *          the variable name
-   * @param range
-   *          the typed converter
+   * @param varName the variable name
+   * @param range   the typed converter
    */
   default void noderange(final String varName, final Range<?> range) {
     throw new UnsupportedOperationException("reading node weights not supported");
@@ -183,17 +182,15 @@ public interface Source<H> extends AutoCloseable {
   /**
    * Passes a (source-specific) hint to the source.
    * 
-   * @param key
-   *          the source-specific key of the hint
-   * @param value
-   *          the value of the hint
+   * @param key   the source-specific key of the hint
+   * @param value the value of the hint
    */
   default void hint(final H key, final Object value) {
   }
 
   /**
-   * Processes the source and builds incidence and attributes. Actual IO might happen earlier to
-   * perform the auto configuration.
+   * Processes the source and builds incidence and attributes. Actual IO might
+   * happen earlier to perform the auto configuration.
    * 
    * @return the result of the parse.
    * @throws IOException forwards exceptions of underlying IO.
@@ -203,8 +200,7 @@ public interface Source<H> extends AutoCloseable {
   /**
    * Closes the source.
    * 
-   * @throws IOException
-   *           Forwards exceptions of underlying IO.
+   * @throws IOException Forwards exceptions of underlying IO.
    * @implNote Overrides the thrown exception type.
    */
   @Override

--- a/modules/io-api/src/main/java/ch/ethz/sn/visone3/io/package-info.java
+++ b/modules/io-api/src/main/java/ch/ethz/sn/visone3/io/package-info.java
@@ -15,6 +15,44 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * IO for reading and writing networks.
+ * This package provides access to IO services for reading and writing networks.
+ * 
+ * <p>
+ * Registered services for network formats can be accessed using the
+ * {@link ch.ethz.sn.visone3.io.IoProvider} class. Services (implementing
+ * {@link ch.ethz.sn.visone3.io.IoService}) provide methods to instantiate
+ * instances of {@link ch.ethz.sn.visone3.io.Source} and
+ * {@link ch.ethz.sn.visone3.io.Sink} to configure and perform the actual network input or output.
+ * 
+ * <p>
+ * A typical code sequence to read network files looks like this:
+ * 
+ * <pre>
+ * SourceFormat ioResult;
+ * try (Source<?> source = IoProvider.getService(format).newSource(streamOrFile)) {
+ *   // configure source by calling suitable methods
+ *   // e.g., define the type and value range of a link attribute
+ *   // (if it is not already specified in the input)
+ *   source.linkrange("link attribute", valueRange);
+ *   ioResult = source.parse();
+ * }
+ * // access results of parsing the input, e.g.,
+ * Network network = ioResult.incidence(); // get the read network
+ * // or  
+ * </pre>
+ * 
+ * <p>
+ * Similarly, code to write network files can take the following form:
+ * 
+ * <pre>
+ * try (Sink sink = IoProvider.getService(format).newSink(outputStream)) {
+ *   // configure sink, such as:
+ *   sink.incidence(network); // choose network to output
+ *   sink.link("example link attribute", linkAttribute); // add a link attribute
+ *   sink.node("example node attribute", nodeAttribute); // or a node attribute 
+ *   // output is completed when the sink is closed
+ * }
+ * </pre>
+ * 
  */
 package ch.ethz.sn.visone3.io;

--- a/modules/io-api/src/main/java/ch/ethz/sn/visone3/io/package-info.java
+++ b/modules/io-api/src/main/java/ch/ethz/sn/visone3/io/package-info.java
@@ -29,7 +29,7 @@
  * 
  * <pre>
  * SourceFormat ioResult;
- * try (Source<?> source = IoProvider.getService(format).newSource(streamOrFile)) {
+ * try (Source&lt;?&gt; source = IoProvider.getService(format).newSource(streamOrFile)) {
  *   // configure source by calling suitable methods
  *   // e.g., define the type and value range of a link attribute
  *   // (if it is not already specified in the input)

--- a/modules/lang-api/src/main/java/ch/ethz/sn/visone3/lang/spi/package-info.java
+++ b/modules/lang-api/src/main/java/ch/ethz/sn/visone3/lang/spi/package-info.java
@@ -17,5 +17,10 @@
 /**
  * Interfaces and classes for service-provider interface to separate the API
  * from the actual implementation.
+ * 
+ * <p>
+ * This package is of particular interest to developers that wish to develop an
+ * alternative implementation of the API, but usually matters little to users of
+ * the library.
  */
 package ch.ethz.sn.visone3.lang.spi;

--- a/modules/lang-impl/src/main/java/ch/ethz/sn/visone3/lang/impl/algorithms/package-info.java
+++ b/modules/lang-impl/src/main/java/ch/ethz/sn/visone3/lang/impl/algorithms/package-info.java
@@ -15,6 +15,8 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Implementation of basic algorithms on primitive arrays and containers.
+ * Implementation of basic algorithms on primitive arrays and containers. The
+ * algorithms are offered in the API in
+ * {@link ch.ethz.sn.visone3.lang.PrimitiveCollections}.
  */
 package ch.ethz.sn.visone3.lang.impl.algorithms;

--- a/modules/lang-impl/src/main/java/ch/ethz/sn/visone3/lang/impl/containers/package-info.java
+++ b/modules/lang-impl/src/main/java/ch/ethz/sn/visone3/lang/impl/containers/package-info.java
@@ -15,6 +15,8 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Implementation of some containers for primitive data types.
+ * Implementation of some containers for primitive data types. The containers
+ * can be obtained in the API using methods of
+ * {@link ch.ethz.sn.visone3.lang.PrimitiveContainers}.
  */
 package ch.ethz.sn.visone3.lang.impl.containers;

--- a/modules/lang-impl/src/main/java/ch/ethz/sn/visone3/lang/impl/mappings/package-info.java
+++ b/modules/lang-impl/src/main/java/ch/ethz/sn/visone3/lang/impl/mappings/package-info.java
@@ -15,6 +15,9 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Implementation of array-like mappings and lists mainly for primivie types.
+ * Implementation of array-like mappings and lists mainly for primitive types.
+ * The mappings and lists can be created using methods in
+ * {@link ch.ethz.sn.visone3.lang.Mappings}, and corresponding collectors are
+ * made available in {@link ch.ethz.sn.visone3.lang.PrimitiveCollectors}.
  */
 package ch.ethz.sn.visone3.lang.impl.mappings;

--- a/modules/lang-impl/src/main/java/ch/ethz/sn/visone3/lang/impl/package-info.java
+++ b/modules/lang-impl/src/main/java/ch/ethz/sn/visone3/lang/impl/package-info.java
@@ -15,6 +15,7 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Implementation of main SPI interface.
+ * Implementation of main SPI interface defined by
+ * {@link ch.ethz.sn.visone3.lang.spi.LangService}.
  */
 package ch.ethz.sn.visone3.lang.impl;

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/blocks/DistanceOperators.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/blocks/DistanceOperators.java
@@ -26,8 +26,38 @@ import ch.ethz.sn.visone3.roles.structures.BinaryRelation;
 import ch.ethz.sn.visone3.roles.structures.Ranking;
 
 /**
- * Provides methods to produce operators calculating pairwise distances of network nodes for the
- * specified role notions.
+ * Provides methods to produce operators calculating pairwise distances of
+ * network nodes from a given role structure for commonly used role notions.
+ * 
+ * <p>
+ * {@link #BASIC} provides access for constructing distance operators that
+ * represent basic operations transforming distance matrices, independent of a
+ * particular definition of role or network structure. {@link #BINARYRELATION},
+ * {@link #RANKING} and {@link #EQUIVALENCE} provide factories to operators that
+ * derive distances based on a provided binary relation, ranking or equivalence,
+ * respectively. These operators compute distances according to a common notion
+ * of role and and network structure.
+ * 
+ * For example, the following code defines a operator computing the distance of
+ * pairwise comparisons from perfect regular equivalence in outgoing direction.
+ * These pairwise comparisons are performed by matching incident relationships
+ * (or edges). According to the operator definition, the matching must also obey
+ * a particular weak ordering among relationships/edges or neighbors (always
+ * matching one relationship/edge with a greater equal one), and admissible
+ * matchings are assigned a user-defined cost. The pairwise distances then
+ * describe the minimum cost achievable under the chosen role notion given the
+ * specified weak ordering and matching costs among relationships/edges.
+ * 
+ * <pre>
+ * Network network = ...;
+ * Comparator&lt;Relationship&gt; edgeComparator = ...;
+ * ToIntBiFunction&lt;Relationship, Relationship&gt; matchingCost = ...;
+ * NetworkView&lt;Relationship, Relationship&gt; outgoingView =
+ *   NetworkView.fromNetworkRelation(network, Direction.OUTGOING);
+ * Operator&lt;ConstMapping.OfInt, IntDistanceMatrix&gt; regularDistanceOp =
+ *   DistanceOperators.EQUIVALENCE.regular().of(outgoingView)
+ *     .comp(edgeComparator).substCost(matchingCost).make();
+ * </pre>
  */
 public class DistanceOperators {
 

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/blocks/RoleOperator.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/blocks/RoleOperator.java
@@ -18,29 +18,37 @@
 package ch.ethz.sn.visone3.roles.blocks;
 
 /**
- * This interface describes the fundamental operations supported by all commonly used notions of
- * roles: relative role ({@link #relative(Object)}), role restriction ({@link #restrict(Object)}),
- * role extension ({@link #extend(Object)}) as well as role interior ({@link #interior(Object)}) and
- * closure ({@link #closure(Object)}).
+ * This interface describes the fundamental operations supported by all commonly
+ * used notions of roles: relative role ({@link #relative(Object)}), role
+ * restriction ({@link #restrict(Object)}), role extension
+ * ({@link #extend(Object)}) as well as role interior
+ * ({@link #interior(Object)}) and closure ({@link #closure(Object)}).
  * 
  * <p>
- * For more details on the nature and properties of these operations, particularly when relative
- * role is isotone, see the papers
+ * For more details on the nature and properties of these operations,
+ * particularly when relative role is isotone, see the papers
  * 
  * <p>
- * Julian Müller, Ulrik Brandes (2019). The evolution of roles. ASONAM '19, August 27-30, 2019,
- * Vancouver, BC, Canada, pp. 406-413, ACM.
+ * Julian Müller, Ulrik Brandes (2019). The evolution of roles. ASONAM '19,
+ * August 27-30, 2019, Vancouver, BC, Canada, pp. 406-413, ACM.
  * 
  * <p>
- * Julian Müller, Ulrik Brandes (2022). The evolution of roles. Social Networks 68:195-208, 2022.
+ * Julian Müller, Ulrik Brandes (2022). The evolution of roles. Social Networks
+ * 68:195-208, 2022.
  * 
+ * <p>
+ * In addition, the DESIGN.md document, provided in the /doc directory that is
+ * included with this library's complete source code in the
+ * <a href="https://muellerj2.github.com/netroles">GitHub repository</a>, also
+ * describes the meaning of these methods for common notions of role in more
+ * detail.
  *
- * @param <T>
- *          A type encoding underlying representation of role structure between nodes in the
- *          network; usually denotes an equivalence
- *          ({@link ch.ethz.sn.visone3.lang.ConstMapping.OfInt}), a ranking
- *          ({@link ch.ethz.sn.visone3.roles.structures.Ranking}) or an arbitrary binary relation
- *          ({@link ch.ethz.sn.visone3.roles.structures.BinaryRelation})
+ * @param <T> A type encoding underlying representation of role structure
+ *            between nodes in the network; usually denotes an equivalence
+ *            ({@link ch.ethz.sn.visone3.lang.ConstMapping.OfInt}), a ranking
+ *            ({@link ch.ethz.sn.visone3.roles.structures.Ranking}) or an
+ *            arbitrary binary relation
+ *            ({@link ch.ethz.sn.visone3.roles.structures.BinaryRelation})
  */
 public interface RoleOperator<T> extends RoleConverter<T, T> {
 

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/blocks/RoleOperators.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/blocks/RoleOperators.java
@@ -33,8 +33,30 @@ import ch.ethz.sn.visone3.roles.structures.BinaryRelation;
 import ch.ethz.sn.visone3.roles.structures.Ranking;
 
 /**
- * Provides factories to produce instances of {@link RoleOperator} for common role notions.
- *
+ * Provides factories to produce instances of {@link RoleOperator} for common
+ * role notions.
+ * 
+ * <p>
+ * {@link #BINARYRELATION}, {@link #RANKING} and {@link #EQUIVALENCE} provide
+ * factories to produce role operators on binary relations, rankings and
+ * equivalences, respectively. Their respective basic() method can be used to
+ * construct role operators that represent basic operations on the respective
+ * structure, independent of a particular definition of role or network
+ * structure. The other methods allow to specify role operators according to a
+ * common notion of role and and network structure.
+ * 
+ * For example, a regular role equivalence notion, defined in outgoing direction
+ * and obeying a particular weak ordering among the edges or neighbors, can be
+ * defined as follows:
+ * 
+ * <pre>
+ * Network network = ...;
+ * Comparator&lt;Relationship&gt; edgeComparator = ...;
+ * NetworkView&lt;Relationship, Relationship&gt; outgoingView =
+ *   NetworkView.fromNetworkRelation(network, Direction.OUTGOING);
+ * RoleOperator&lt;ConstMapping.OfInt&gt; regularRoleOp =
+ *   RoleOperators.EQUIVALENCE.regular().of(outgoingView).comp(edgeComparator).make();
+ * </pre>
  */
 public class RoleOperators {
 

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/blocks/builders/package-info.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/blocks/builders/package-info.java
@@ -16,6 +16,9 @@
  */
 /**
  * Builder interfaces for constructing role or distance operators of notions of
- * roles.
+ * roles. The interfaces are used to define the API for specifying role and
+ * distance operators offered by
+ * {@link ch.ethz.sn.visone3.roles.blocks.RoleOperators} and
+ * {@link ch.ethz.sn.visone3.roles.blocks.DistanceOperators}.
  */
 package ch.ethz.sn.visone3.roles.blocks.builders;

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/blocks/bundles/package-info.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/blocks/bundles/package-info.java
@@ -21,6 +21,9 @@
  * <p>
  * A bundle bundles the factories for distance or role operators for one
  * specific representation of role structure (equivalence, ranking or binary
- * relation).
+ * relation). These bundles are used in defining the API for specifying role and
+ * distance operators offered by
+ * {@link ch.ethz.sn.visone3.roles.blocks.RoleOperators} and
+ * {@link ch.ethz.sn.visone3.roles.blocks.DistanceOperators}.
  */
 package ch.ethz.sn.visone3.roles.blocks.bundles;

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/blocks/factories/package-info.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/blocks/factories/package-info.java
@@ -15,7 +15,10 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Factory interfaces to produce builders for role or distance operators of
- * notions of roles.
+ * This package defines factory interfaces to produce builders for role or
+ * distance operators of notions of roles. The interfaces are used to specify
+ * the API for specifying role and distance operators offered by
+ * {@link ch.ethz.sn.visone3.roles.blocks.RoleOperators} and
+ * {@link ch.ethz.sn.visone3.roles.blocks.DistanceOperators}.
  */
 package ch.ethz.sn.visone3.roles.blocks.factories;

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/blocks/package-info.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/blocks/package-info.java
@@ -54,8 +54,8 @@
  * 
  * <pre>
  * Network network = ...;
- * NetworkView<?, ?> outgoingView = NetworkView.fromNetworkRelation(network, Direction.OUTGOING);
- * NetworkView<?, ?> incomingView = NetworkView.fromNetworkRelation(network, Direction.INCOMING);
+ * NetworkView&lt;?, ?&gt; outgoingView = NetworkView.fromNetworkRelation(network, Direction.OUTGOING);
+ * NetworkView&lt;?, ?&gt; incomingView = NetworkView.fromNetworkRelation(network, Direction.INCOMING);
  * // outgoing direction only 
  * RoleOperator&lt;ConstMapping.OfInt&gt; outgoingRegularOp = RoleOperators.EQUIVALENCE.regular()
  *   .of(outgoingView).make();
@@ -89,14 +89,14 @@
  * 
  * <pre>
  * Network network = ...;
- * NetworkView<?, ?> outgoingView = NetworkView.fromNetworkRelation(network, Direction.OUTGOING);
+ * NetworkView&lt;?, ?&gt; outgoingView = NetworkView.fromNetworkRelation(network, Direction.OUTGOING);
  * RoleOperator&lt;ConstMapping.OfInt&gt; errortolerantOp = Operators.parallel( //
  *     Reducers.EQUIVALENCE.meet(), //
  *     Operators.composeRoleOp( //
  *         Operators.composeOp( //
  *             Operators.composeOp( // threshold pairwise distances from equitable equivalence by one
  *                 DistanceOperators.EQUIVALENCE.equitable().of(outgoingView).make(),
- *                 Converters.thresholdDistances((i, j) -> 1)),
+ *                 Converters.thresholdDistances((i, j) -&gt; 1)),
  *             // symmetrize (at most distance one in both directions)
  *             RoleOperators.BINARYRELATION.basic().symmetrize()),
  *         Converters.strongComponentsAsEquivalence()), // close on symmetric comparisons transitively

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/blocks/package-info.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/blocks/package-info.java
@@ -21,24 +21,86 @@
  * <p>
  * This package is organized as follows:
  * <ul>
- * <li>The Operators class offers methods for composing operators in a
- * data-flow-like manner. The operators can be composed sequentially (series(),
- * compose*()) or in parallel working on the same initial input followed by a
- * reduction operation (parallel()).</li>
- * <li>The RoleOperators class provides builders to construct operators for
- * established notions of role on the lattices of equivalences, rankings and
- * binary relations. Moreover, it also offers basic operators working on these
- * lattices.</li>
- * <li>The DistanceOperators class provides builders to construct operators
- * producing distances based on established notions of role, as well as some
- * basic operators working on distances.</li>
- * <li>The Reducers class provides reduction operations for equivalences,
- * rankings, binary relations and distances. These are intended to be used in
- * conjunction with the Operators.parallel() methods.</li>
- * <li>The Converters class provides operators representing conversion
- * operations between the different kinds of role structure representations
- * (equivalence, ranking, binary relation) and distance matrices.
+ * <li>The {@link ch.ethz.sn.visone3.roles.blocks.Operators} class offers
+ * methods for composing operators in a data-flow-like manner. The operators can
+ * be composed sequentially (series(), compose*()) or in parallel working on the
+ * same initial input followed by a reduction operation (parallel()).</li>
+ * <li>The {@link ch.ethz.sn.visone3.roles.blocks.RoleOperators} class provides
+ * builders to construct operators for established notions of role on the
+ * lattices of equivalences, rankings and binary relations. Moreover, it also
+ * offers basic operators working on these lattices.</li>
+ * <li>The {@link ch.ethz.sn.visone3.roles.blocks.DistanceOperators} class
+ * provides builders to construct operators producing distances based on
+ * established notions of role, as well as some basic operators working on
+ * distances.</li>
+ * <li>The {@link ch.ethz.sn.visone3.roles.blocks.Reducers} class provides
+ * reduction operations for equivalences, rankings, binary relations and
+ * distances. These are mainly intended to be used in conjunction with the
+ * Operators.parallel() methods to combine several structures of the same type
+ * into a single result.</li>
+ * <li>The {@link ch.ethz.sn.visone3.roles.blocks.Converters} class provides
+ * operators representing conversion operations between the different kinds of
+ * role structure representations (equivalence, ranking, binary relation) and
+ * distance matrices.
  * <li>
  * </ul>
+ * 
+ * <p>
+ * For example, a role operator that applies the notion of regular equivalence
+ * in both edge directions on a network can be defined as follows using the APIs
+ * of {@link ch.ethz.sn.visone3.roles.blocks.Operators}
+ * {@link ch.ethz.sn.visone3.roles.blocks.RoleOperators} and
+ * {@link ch.ethz.sn.visone3.roles.blocks.Reducers}:
+ * 
+ * <pre>
+ * Network network = ...;
+ * NetworkView<?, ?> outgoingView = NetworkView.fromNetworkRelation(network, Direction.OUTGOING);
+ * NetworkView<?, ?> incomingView = NetworkView.fromNetworkRelation(network, Direction.INCOMING);
+ * // outgoing direction only 
+ * RoleOperator&lt;ConstMapping.OfInt&gt; outgoingRegularOp = RoleOperators.EQUIVALENCE.regular()
+ *   .of(outgoingView).make();
+ * // incoming direction only 
+ * RoleOperator&lt;ConstMapping.OfInt&gt; incomingRegularOp = RoleOperators.EQUIVALENCE.regular()
+ *   .of(incomingView).make();
+ * RoleOperator&lt;ConstMapping.OfInt&gt; bidiRegularOp = Operators.parallel(
+ *     // we apply the unidirectional operators in parallel
+ *     // and combine them through intersection
+ *     // (which is the meet of the equivalence lattice)
+ *     Reducers.EQUIVALENCE.meet(), 
+ *     outgoingRegularOp, // regular roles operator in outgoing direction only
+ *     incomingRegularOp // regular roles operator in incoming direction only
+ *   );
+ * </pre>
+ * 
+ * <p>
+ * Similarly, error-tolerant role structures can be defined by thresholding
+ * deviations from the underlying notion of equivalence. For example, we can
+ * define an error-tolerant notion of exact equivalence, which
+ * <ul>
+ * <li>still accepts a deviation from perfect exact equivalence by at most in
+ * both directions of comparison as two nodes being equivalent,</li>
+ * <li>but always considers isolates and non-isolates as non-equivalent,
+ * and</li>
+ * <li>converts the binary relation obtained after thresholding to an
+ * equivalence by applying transitive closure.</li>
+ * </ul>
+ * The following code defines an operator describing this error-tolerant kind of
+ * role equivalence for the outgoing edge direction:
+ * 
+ * <pre>
+ * Network network = ...;
+ * NetworkView<?, ?> outgoingView = NetworkView.fromNetworkRelation(network, Direction.OUTGOING);
+ * RoleOperator&lt;ConstMapping.OfInt&gt; errortolerantOp = Operators.parallel( //
+ *     Reducers.EQUIVALENCE.meet(), //
+ *     Operators.composeRoleOp( //
+ *         Operators.composeOp( //
+ *             Operators.composeOp( // threshold pairwise distances from equitable equivalence by one
+ *                 DistanceOperators.EQUIVALENCE.equitable().of(outgoingView).make(),
+ *                 Converters.thresholdDistances((i, j) -> 1)),
+ *             // symmetrize (at most distance one in both directions)
+ *             RoleOperators.BINARYRELATION.basic().symmetrize()),
+ *         Converters.strongComponentsAsEquivalence()), // close on symmetric comparisons transitively
+ *     RoleOperators.EQUIVALENCE.weak().of(networkView).make()); // and split off isolates
+ * </pre>
  */
 package ch.ethz.sn.visone3.roles.blocks;

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/distances/package-info.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/distances/package-info.java
@@ -15,6 +15,8 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Classes to represent and work with pairwise distance matrices.
+ * This packages defines pairwise distance matrices and provides methods to
+ * construct and work with them. Such methods are provided in
+ * {@link ch.ethz.sn.visone3.roles.distances.DistanceMatrices}.
  */
 package ch.ethz.sn.visone3.roles.distances;

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/position/NetworkView.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/position/NetworkView.java
@@ -27,10 +27,10 @@ import ch.ethz.sn.visone3.networks.Relationship;
  * expressed by some kind of ties, in it.
  * 
  * <p>
- * This interface can be implemented to allow the roles library to work directly
- * on network data structures offered by other libraries, without having to
- * convert the network data into the library's standard network data format
- * defined by {@link Network}.
+ * This interface can be implemented to allow this library to work directly on
+ * network data structures offered by other libraries, without having to convert
+ * the network data into the library's standard network data format defined by
+ * {@link Network}.
  * 
  * @param <T> type of (forward) ties from the nodes.
  * @param <U> type of backward ties pointing to the nodes.

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/position/package-info.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/position/package-info.java
@@ -17,5 +17,9 @@
 /**
  * Wrapper interfaces for networks. Also includes a utility method to construct
  * such a wrapper interface for the library's default network representation.
+ * 
+ * <p>
+ * These wrapper interfaces can be implemented to make this library work
+ * directly on network representations offered by other libraries.
  */
 package ch.ethz.sn.visone3.roles.position;

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/spi/package-info.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/spi/package-info.java
@@ -16,5 +16,10 @@
  */
 /**
  * Classes for service-provider interface or API/Implementation separation.
+ * 
+ * <p>
+ * This package is of particular interest to developers that wish to develop an
+ * alternative implementation of the API, but usually matters little to users of
+ * the library.
  */
 package ch.ethz.sn.visone3.roles.spi;

--- a/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/structures/package-info.java
+++ b/modules/roles-api/src/main/java/ch/ethz/sn/visone3/roles/structures/package-info.java
@@ -15,6 +15,18 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Classes to represent and work with rankings and binary relations.
+ * This package provides classes to represent and work with rankings and binary
+ * relations.
+ * 
+ * <p>
+ * Rankings and binary relations can be constructed using the builders provided
+ * by the {@link ch.ethz.sn.visone3.roles.structures.RelationBuilders} class, as
+ * well as using methods provided in
+ * {@link ch.ethz.sn.visone3.roles.structures.Rankings} and
+ * {@link ch.ethz.sn.visone3.roles.structures.BinaryRelations}.
+ * {@link ch.ethz.sn.visone3.roles.structures.Relations},
+ * {@link ch.ethz.sn.visone3.roles.structures.BinaryRelations} and
+ * {@link ch.ethz.sn.visone3.roles.structures.Rankings} also provide methods for
+ * working with binary relations and rankings.
  */
 package ch.ethz.sn.visone3.roles.structures;

--- a/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/algorithms/package-info.java
+++ b/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/algorithms/package-info.java
@@ -16,6 +16,12 @@
  */
 /**
  * Algorithms for computing role structures and distances, mainly for
- * established role notions.
+ * established role notions. This package is the algorithmic basis of standard
+ * role and distance operators that can be constructed using the API in the
+ * {@link ch.ethz.sn.visone3.roles.blocks.RoleOperators} and
+ * {@link ch.ethz.sn.visone3.roles.blocks.DistanceOperators} classes. The actual
+ * implementing role operator and distance operator classes are defined in
+ * packages {@link ch.ethz.sn.visone3.roles.impl.blocks.factories} and
+ * {@link ch.ethz.sn.visone3.roles.impl.blocks.factories.dist}.
  */
 package ch.ethz.sn.visone3.roles.impl.algorithms;

--- a/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/blocks/basic/package-info.java
+++ b/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/blocks/basic/package-info.java
@@ -15,6 +15,8 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Composed operators obtained from two or more other operators.
+ * Composed operators obtained from two or more other interior operators. This
+ * package provides the actual implementation of the
+ * {@link ch.ethz.sn.visone3.roles.blocks.Operators} class.
  */
 package ch.ethz.sn.visone3.roles.impl.blocks.basic;

--- a/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/blocks/converters/package-info.java
+++ b/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/blocks/converters/package-info.java
@@ -16,6 +16,7 @@
  */
 /**
  * Conversion operators between equivalences, rankings, binary relations and
- * distances.
+ * distances. This package provides the actual implementation of the
+ * {@link ch.ethz.sn.visone3.roles.blocks.Converters} class.
  */
 package ch.ethz.sn.visone3.roles.impl.blocks.converters;

--- a/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/blocks/factories/dist/package-info.java
+++ b/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/blocks/factories/dist/package-info.java
@@ -15,6 +15,12 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Implementations of factories for distance operators.
+ * Implementations of factories for distance operators. This package provides
+ * the actual implementation of the role operator definition pipeline offered in
+ * the {@link ch.ethz.sn.visone3.roles.blocks.DistanceOperators} class. The
+ * algorithms in the {@link ch.ethz.sn.visone3.roles.impl.algorithms} class are
+ * also wrapped by suitable distance operator classes (which in turn are mostly
+ * specified as anonymous classes in the corresponding factory implementation
+ * classes).
  */
 package ch.ethz.sn.visone3.roles.impl.blocks.factories.dist;

--- a/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/blocks/factories/package-info.java
+++ b/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/blocks/factories/package-info.java
@@ -15,6 +15,11 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Implementations of factories for role operators.
+ * Implementations of factories for role operators. This package provides the
+ * actual implementation of the role operator definition pipeline offered in the
+ * {@link ch.ethz.sn.visone3.roles.blocks.RoleOperators} class. The algorithms
+ * in the {@link ch.ethz.sn.visone3.roles.impl.algorithms} class are also
+ * wrapped by suitable role operator classes (which in turn are mostly specified
+ * as anonymous classes in the corresponding factory implementation classes).
  */
 package ch.ethz.sn.visone3.roles.impl.blocks.factories;

--- a/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/blocks/reducers/dist/package-info.java
+++ b/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/blocks/reducers/dist/package-info.java
@@ -15,6 +15,7 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Reduction operations for distances.
+ * Reduction operations for distances. The operators are made available in the
+ * {@link ch.ethz.sn.visone3.roles.blocks.Reducers} class.
  */
 package ch.ethz.sn.visone3.roles.impl.blocks.reducers.dist;

--- a/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/blocks/reducers/eq/package-info.java
+++ b/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/blocks/reducers/eq/package-info.java
@@ -15,6 +15,7 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Reduction operations for equivalences.
+ * Reduction operations for equivalences. The operators are made available in
+ * the {@link ch.ethz.sn.visone3.roles.blocks.Reducers} class.
  */
 package ch.ethz.sn.visone3.roles.impl.blocks.reducers.eq;

--- a/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/blocks/reducers/rank/package-info.java
+++ b/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/blocks/reducers/rank/package-info.java
@@ -15,6 +15,7 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Reduction operations for rankings.
+ * Reduction operations for rankings. The operators are made available in the
+ * {@link ch.ethz.sn.visone3.roles.blocks.Reducers} class.
  */
 package ch.ethz.sn.visone3.roles.impl.blocks.reducers.rank;

--- a/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/blocks/reducers/rel/package-info.java
+++ b/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/blocks/reducers/rel/package-info.java
@@ -15,6 +15,7 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Reduction operations for binary relations.
+ * Reduction operations for binary relations. The operators are made available
+ * in the {@link ch.ethz.sn.visone3.roles.blocks.Reducers} class.
  */
 package ch.ethz.sn.visone3.roles.impl.blocks.reducers.rel;

--- a/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/structures/package-info.java
+++ b/modules/roles-impl/src/main/java/ch/ethz/sn/visone3/roles/impl/structures/package-info.java
@@ -15,6 +15,8 @@
  * along with netroles.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Data structures and basic operations for binary relations and rankings.
+ * Implementations of data structures and basic operations for binary relations
+ * and rankings. Construction and basic operations are made available in the
+ * {@link ch.ethz.sn.visone3.roles.structures} package.
  */
 package ch.ethz.sn.visone3.roles.impl.structures;


### PR DESCRIPTION
adds some example code and more explanations on how API packages or classes are supposed to be used