### PR TITLE
prepare release of version 1.0

### DIFF
--- a/.github/workflows/gradle_buildbinariesfromtag.yml
+++ b/.github/workflows/gradle_buildbinariesfromtag.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Create publication artifacts using Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: publish
+        arguments: clean publish
     - name: Gather release binaries
       run: |
         shopt -s globstar

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ wrapper {
 
 allprojects {
   group 'io.github.muellerj2'
-  version '0.3-SNAPSHOT'
+  version '1.0'
   
   apply plugin: 'com.github.hierynomus.license'
   

--- a/modules/core-api/core-api.gradle
+++ b/modules/core-api/core-api.gradle
@@ -21,7 +21,7 @@ publishing {
       
       pom {
         name = 'netroles Networks API'
-        description = 'API for networks used in netroles library'
+        description = 'API module of netroles library providing network representations'
         url = 'https://github.com/muellerj2/netroles'
         licenses {
           license {

--- a/modules/io-api/io-api.gradle
+++ b/modules/io-api/io-api.gradle
@@ -22,7 +22,7 @@ publishing {
       from components.java
       pom {
         name = 'netroles IO API'
-        description = 'API of network file IO for netroles library'
+        description = 'API module of netroles library for network file IO'
         url = 'https://github.com/muellerj2/netroles'
         licenses {
           license {

--- a/modules/lang-api/lang-api.gradle
+++ b/modules/lang-api/lang-api.gradle
@@ -19,7 +19,7 @@ publishing {
       
       pom {
         name = 'netroles Lang API'
-        description = 'API specifying fundamental utility classes used by netroles'
+        description = 'API module of netroles library providing fundamental utility classes'
         url = 'https://github.com/muellerj2/netroles'
         licenses {
           license {

--- a/modules/roles-api/roles-api.gradle
+++ b/modules/roles-api/roles-api.gradle
@@ -20,7 +20,7 @@ publishing {
       
       pom {
         name = 'netroles API'
-        description = 'API of netroles library for role analysis in networks'
+        description = 'API module of netroles library for role equivalence analysis in networks'
         url = 'https://github.com/muellerj2/netroles'
         licenses {
           license {

--- a/modules/roles-impl/roles-impl.gradle
+++ b/modules/roles-impl/roles-impl.gradle
@@ -35,7 +35,7 @@ publishing {
 
       pom {
         name = 'netroles Engine'
-        description = 'netroles role analysis engine'
+        description = 'netroles role equivalence analysis engine'
         url = 'https://github.com/muellerj2/netroles'
         licenses {
           license {


### PR DESCRIPTION
set version number, align Maven descriptions of API modules and clean before building using Gradle (to make unintended side effects of Gradle caches less likely)